### PR TITLE
refactor(stream): make serialization not return a Result

### DIFF
--- a/examples/receiver.rs
+++ b/examples/receiver.rs
@@ -18,13 +18,15 @@ fn main() {
     let future = connect_async("ws://bob:bob@localhost:7768")
         .map_err(|err| {
             println!("{}", err);
-        }).and_then(move |plugin| {
-            println!("Conected receiver");
+        })
+        .and_then(move |plugin| {
+            println!("Connected receiver");
 
             listen_with_random_secret(plugin, 3000)
                 .map_err(|err| {
                     println!("Error listening {:?}", err);
-                }).and_then(|listener| {
+                })
+                .and_then(|listener| {
                     listener
                         .for_each(|(id, conn)| {
                             println!("Got incoming connection {}", id);
@@ -38,7 +40,8 @@ fn main() {
                                         .for_each(|amount| {
                                             println!("Got incoming money {}", amount);
                                             Ok(())
-                                        }).and_then(move |_| {
+                                        })
+                                        .and_then(move |_| {
                                             println!("Money stream {} closed", stream_id);
                                             Ok(())
                                         });
@@ -49,7 +52,8 @@ fn main() {
                                     let handle_data = read_to_end(stream.data, data)
                                         .map_err(|err| {
                                             println!("Error reading data: {}", err);
-                                        }).and_then(|(_stream, data)| {
+                                        })
+                                        .and_then(|(_stream, data)| {
                                             println!(
                                                 "Got incoming data: {}",
                                                 String::from_utf8(Vec::from(&data[..])).unwrap()
@@ -58,16 +62,19 @@ fn main() {
                                         });
                                     tokio::spawn(handle_data);
                                     Ok(())
-                                }).then(|_| {
+                                })
+                                .then(|_| {
                                     println!("Connection was closed");
                                     Ok(())
                                 });
 
                             tokio::spawn(handle_connection);
                             Ok(())
-                        }).map_err(|err| {
+                        })
+                        .map_err(|err| {
                             println!("Error in listener {:?}", err);
-                        }).map(|_| ())
+                        })
+                        .map(|_| ())
                 })
         });
 

--- a/examples/sender.rs
+++ b/examples/sender.rs
@@ -17,7 +17,8 @@ fn main() {
     let future = connect_to_moneyd()
         .map_err(|err| {
             println!("{}", err);
-        }).and_then(move |plugin| {
+        })
+        .and_then(move |plugin| {
             println!("Conected sender");
 
             // pay(plugin, "http://localhost:3000", 100)
@@ -29,7 +30,8 @@ fn main() {
             connect_async(plugin, "http://localhost:3000")
                 .map_err(|err| {
                     println!("Error connecting to SPSP server {:?}", err);
-                }).and_then(|connection| {
+                })
+                .and_then(|connection| {
                     println!("Creating new stream and sending money");
                     let mut stream = connection.create_stream();
                     stream
@@ -44,16 +46,19 @@ fn main() {
                                 .write(&bytes[..])
                                 .map_err(|err| {
                                     println!("Error writing {}", err);
-                                }).unwrap();
+                                })
+                                .unwrap();
                             println!("Sent data");
                             println!("Closing connection");
                             connection.close()
-                        }).and_then(|_| {
+                        })
+                        .and_then(|_| {
                             println!("Closed connection");
                             Ok(())
                         })
                 })
-        }).then(|_| Ok(()));
+        })
+        .then(|_| Ok(()));
 
     tokio::runtime::run(future);
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,11 +95,13 @@ fn send_spsp_payment(btp_server: &str, receiver: String, amount: u64, quiet: boo
         .map_err(|err| {
             eprintln!("Error connecting to BTP server: {:?}", err);
             eprintln!("(Hint: is moneyd running?)");
-        }).and_then(move |plugin| {
+        })
+        .and_then(move |plugin| {
             spsp::pay(plugin, &receiver, amount)
                 .map_err(|err| {
                     eprintln!("Error sending SPSP payment: {:?}", err);
-                }).and_then(move |delivered| {
+                })
+                .and_then(move |delivered| {
                     if !quiet {
                         println!(
                             "Sent: {}, delivered: {} (in the receiver's units)",

--- a/src/ildcp.rs
+++ b/src/ildcp.rs
@@ -94,7 +94,8 @@ pub fn get_config(
                         "Got error while waiting for ILDCP response: {:?}",
                         err
                     ))
-                }).timeout(DurationStd::from_millis(31))
+                })
+                .timeout(DurationStd::from_millis(31))
                 .map_err(|_| Error("Timed out waiting for ILDCP response".to_string()))
                 .and_then(|(next, plugin)| {
                     if let Some((_request_id, IlpPacket::Fulfill(fulfill))) = next {

--- a/src/plugin/btp/client.rs
+++ b/src/plugin/btp/client.rs
@@ -97,7 +97,8 @@ pub fn connect_btp_stream(
                         .and_then(move |(_auth_response, plugin)| {
                             info!("Connected to server: {}", server_without_auth);
                             Ok(plugin)
-                        }).map_err(|(err, _plugin)| {
+                        })
+                        .map_err(|(err, _plugin)| {
                             PluginBtpError(format!("Error getting auth response: {:?}", err))
                         })
                 })

--- a/src/plugin/btp/ilp_packet_stream.rs
+++ b/src/plugin/btp/ilp_packet_stream.rs
@@ -137,7 +137,8 @@ where
             .map(move |result| match result {
                 AsyncSink::Ready => AsyncSink::Ready,
                 AsyncSink::NotReady(_) => AsyncSink::NotReady(item_clone),
-            }).map_err(|err| {
+            })
+            .map_err(|err| {
                 error!("Error sending packet {:?}", err);
             })
     }

--- a/src/plugin/btp/packet_stream.rs
+++ b/src/plugin/btp/packet_stream.rs
@@ -66,7 +66,8 @@ where
                     debug!("BTP packet sink was not ready to send {:?}", item);
                     AsyncSink::NotReady(item)
                 }
-            }).map_err(|err| {
+            })
+            .map_err(|err| {
                 error!("Error sending BTP packet: {}", err);
             })
     }

--- a/src/spsp.rs
+++ b/src/spsp.rs
@@ -98,7 +98,8 @@ where
                     .or_else(|_err| {
                         // We don't care if there was an issue closing the connection
                         Ok(())
-                    }).and_then(move |_| Ok(total_delivered))
+                    })
+                    .and_then(move |_| Ok(total_delivered))
             })
     })
 }

--- a/src/stream/congestion.rs
+++ b/src/stream/congestion.rs
@@ -140,7 +140,8 @@ impl CongestionController {
                 format!("{}", Utc::now().timestamp_millis()),
                 format!("{}", self.max_in_flight),
                 format!("{}", amount_sent),
-            ]).unwrap();
+            ])
+            .unwrap();
         self.csv_writer.flush().unwrap();
     }
 }

--- a/src/stream/connection.rs
+++ b/src/stream/connection.rs
@@ -252,7 +252,7 @@ impl Connection {
                 frames,
             };
 
-            let encrypted = stream_packet.to_encrypted(&self.shared_secret).unwrap();
+            let encrypted = stream_packet.to_encrypted(&self.shared_secret);
             let condition = generate_condition(&self.shared_secret, &encrypted);
             let prepare = IlpPrepare::new(
                 self.destination_account.to_string(),
@@ -346,7 +346,8 @@ impl Connection {
                 .unbounded_send((
                     request_id,
                     IlpPacket::Reject(IlpReject::new("F02", "", "", Bytes::new())),
-                )).map_err(|err| {
+                ))
+                .map_err(|err| {
                     error!("Error sending Reject {} {:?}", request_id, err);
                 })?;
             return Ok(());
@@ -399,7 +400,7 @@ impl Connection {
             }
         }
 
-        self.handle_incoming_data(&stream_packet).unwrap();
+        self.handle_incoming_data(&stream_packet)?;
 
         self.handle_stream_closes(&stream_packet);
 
@@ -413,7 +414,7 @@ impl Connection {
                 prepare_amount: prepare.amount,
                 frames: response_frames,
             };
-            let encrypted_response = response_packet.to_encrypted(&self.shared_secret).unwrap();
+            let encrypted_response = response_packet.to_encrypted(&self.shared_secret);
             let fulfill =
                 IlpPacket::Fulfill(IlpFulfill::new(fulfillment.clone(), encrypted_response));
             debug!(
@@ -430,7 +431,7 @@ impl Connection {
                 prepare_amount: prepare.amount,
                 frames: response_frames,
             };
-            let encrypted_response = response_packet.to_encrypted(&self.shared_secret).unwrap();
+            let encrypted_response = response_packet.to_encrypted(&self.shared_secret);
             let reject = IlpPacket::Reject(IlpReject::new("F99", "", "", encrypted_response));
             debug!(
                 "Rejecting request {} and including encrypted stream packet {:?}",
@@ -711,7 +712,7 @@ impl Connection {
             0,
             random_condition(),
             Utc::now() + Duration::seconds(30),
-            stream_packet.to_encrypted(&self.shared_secret).unwrap(),
+            stream_packet.to_encrypted(&self.shared_secret),
         ));
         self.outgoing.unbounded_send((request_id, prepare)).unwrap();
     }

--- a/src/stream/data_money_stream.rs
+++ b/src/stream/data_money_stream.rs
@@ -265,7 +265,7 @@ impl DataStream {
         let mut chunks: Vec<Bytes> = Vec::new();
         let mut size: usize = 0;
         while size < max_size && !outgoing.buffer.is_empty() {
-            let mut chunk = outgoing.buffer.pop_front().unwrap();
+            let mut chunk = outgoing.buffer.pop_front()?;
             if chunk.len() >= max_size - size {
                 chunks.push(chunk.split_to(max_size - size));
                 size = max_size;

--- a/src/stream/listener.rs
+++ b/src/stream/listener.rs
@@ -209,12 +209,13 @@ impl StreamListener {
                         prepare_amount: 0,
                         frames: vec![],
                     };
-                    let data = response_packet.to_encrypted(&shared_secret).unwrap();
+                    let data = response_packet.to_encrypted(&shared_secret);
                     self.outgoing_sender
                         .unbounded_send((
                             request_id,
                             IlpPacket::Reject(IlpReject::new("F99", "", "", data)),
-                        )).map_err(|_| {
+                        ))
+                        .map_err(|_| {
                             error!("Error sending reject");
                         })?;
                     return Ok(None);
@@ -228,7 +229,8 @@ impl StreamListener {
                     .unbounded_send((
                         request_id,
                         IlpPacket::Reject(IlpReject::new("F02", "", "", Bytes::new())),
-                    )).map_err(|_| {
+                    ))
+                    .map_err(|_| {
                         error!("Error sending reject");
                     })?;
                 return Ok(None);
@@ -263,7 +265,8 @@ impl StreamListener {
                     "Error forwarding packets from connection to outgoing sink {:?}",
                     err
                 );
-            }).send_all(outgoing_rx)
+            })
+            .send_all(outgoing_rx)
             .then(|_| Ok(()));
         tokio::spawn(forward_outgoing);
 
@@ -314,7 +317,8 @@ impl StreamListener {
                         connection_id, err
                     );
                     Ok(())
-                }).unwrap();
+                })
+                .unwrap();
         } else {
             warn!(
                 "Ignoring response packet that did not correspond to outgoing request: {} {:?}",
@@ -399,7 +403,8 @@ impl Stream for StreamListener {
                             .unbounded_send((
                                 request_id,
                                 IlpPacket::Reject(IlpReject::new("F02", "", "", Bytes::new())),
-                            )).map_err(|_| {
+                            ))
+                            .map_err(|_| {
                                 error!("Error sending reject");
                             })?;
                         return Ok(Async::NotReady);

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -42,7 +42,8 @@ where
         .map(|_| ())
         .map_err(|err| {
             error!("Error forwarding request to plugin: {:?}", err);
-        }).then(move |_| {
+        })
+        .then(move |_| {
             trace!("Finished forwarding packets from Connection to plugin");
             drop(exit);
             Ok(())
@@ -56,7 +57,8 @@ where
                 "Error forwarding packet from plugin to Connection: {:?}",
                 err.into_inner()
             );
-        }).send_all(stream)
+        })
+        .send_all(stream)
         .then(|_| {
             trace!("Finished forwarding packets from plugin to Connection");
             Ok(())
@@ -135,7 +137,8 @@ mod tests {
                                             .map_err(|err| panic!(err))
                                             .map(|_| ())
                                     })
-                            }).and_then(move |_| conn.close())
+                            })
+                            .and_then(move |_| conn.close())
                     })
             });
         let mut runtime = Runtime::new().unwrap();


### PR DESCRIPTION
Unfortunately, `rustfmt` included some changes.

Notable changes include:
- using `MutBufOerExt` to remove unnecessary Results in `src/stream/packet.rs`
- removal of `unwrap()` functions in `src/stream/connection.rs`
- using `expect()` instead of `unwrap()` in `crypto.rs`
- use `?` operator on `std::collections::Hashmap` instead of `unwrap()` in `src/stream/data_money_stream.rs
`

Sorry for the `rustfmt` inconvenience. Thank you for any additional feedback!