### PR TITLE
Fix #37

### DIFF
--- a/crates/interledger-http/src/lib.rs
+++ b/crates/interledger-http/src/lib.rs
@@ -13,6 +13,9 @@ use url::Url;
 mod client;
 mod server;
 
+/// Originally from [interledger-relay](https://github.com/coilhq/interledger-relay/blob/master/crates/interledger-relay/src/combinators/limit_stream.rs).
+mod limit_stream;
+
 pub use self::client::HttpClientService;
 pub use self::server::HttpServerService;
 

--- a/crates/interledger-http/src/limit_stream.rs
+++ b/crates/interledger-http/src/limit_stream.rs
@@ -1,0 +1,155 @@
+// Copyright 2019 Coil Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is originally from https://github.com/coilhq/interledger-relay/blob/master/crates/interledger-relay/src/combinators/limit_stream.rs
+// and is modified to accept Option value for limitation.
+
+use std::error::Error;
+use std::fmt;
+
+use futures::prelude::*;
+
+/// A stream combinator which returns a maximum number of bytes before failing.
+#[derive(Debug)]
+pub struct LimitStream<S> {
+    is_limited: bool,
+    remaining: usize,
+    stream: S,
+}
+
+impl<S> LimitStream<S> {
+    #[inline]
+    pub fn new(max_bytes: Option<usize>, stream: S) -> Self {
+        LimitStream {
+            is_limited: max_bytes.is_some(),
+            remaining: max_bytes.unwrap_or_default(),
+            stream,
+        }
+    }
+}
+
+impl<S> Stream for LimitStream<S>
+where
+    S: Stream,
+    S::Item: AsRef<[u8]>,
+    S::Error: Error,
+{
+    type Item = S::Item;
+    type Error = LimitStreamError<S::Error>;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let item = self.stream.poll()?;
+
+        if self.is_limited == false {
+            return Ok(item);
+        }
+
+        if let Async::Ready(Some(chunk)) = &item {
+            let chunk_size = chunk.as_ref().len();
+            match self.remaining.checked_sub(chunk_size) {
+                Some(remaining) => self.remaining = remaining,
+                None => {
+                    self.remaining = 0;
+                    return Err(LimitStreamError::LimitExceeded);
+                }
+            }
+        }
+
+        Ok(item)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LimitStreamError<E> {
+    LimitExceeded,
+    StreamError(E),
+}
+
+impl<E: Error + 'static> Error for LimitStreamError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self {
+            LimitStreamError::LimitExceeded => None,
+            LimitStreamError::StreamError(error) => Some(error),
+        }
+    }
+}
+
+impl<E: Error> From<E> for LimitStreamError<E> {
+    fn from(error: E) -> Self {
+        LimitStreamError::StreamError(error)
+    }
+}
+
+impl<E: Error> fmt::Display for LimitStreamError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LimitStreamError::LimitExceeded => f.write_str("LimitExceeded"),
+            LimitStreamError::StreamError(error) => write!(f, "StreamError({})", error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_limit_stream {
+    use bytes::Bytes;
+
+    use super::*;
+
+    #[test]
+    fn test_stream() {
+        const SIZE: usize = 256;
+        let buffer = Bytes::from(&[0x00; SIZE][..]);
+
+        // Buffer size is below limit.
+        assert_eq!(
+            collect_limited_stream(buffer.clone(), Some(SIZE + 1)).unwrap(),
+            buffer,
+        );
+        // Buffer size is equal to the limit.
+        assert_eq!(
+            collect_limited_stream(buffer.clone(), Some(SIZE)).unwrap(),
+            buffer,
+        );
+        // Buffer size is above the limit.
+        assert!({
+            collect_limited_stream(buffer.clone(), Some(SIZE - 1))
+                .unwrap_err()
+                .is_limit_exceeded()
+        });
+        // Stream is not limited.
+        assert_eq!(
+            collect_limited_stream(buffer.clone(), None).unwrap(),
+            buffer,
+        );
+    }
+
+    fn collect_limited_stream(
+        buffer: Bytes,
+        limit: Option<usize>,
+    ) -> Result<Bytes, LimitStreamError<hyper::Error>> {
+        let stream = hyper::Body::from(buffer);
+        LimitStream::new(limit, stream)
+            .concat2()
+            .wait()
+            .map(|chunk| Bytes::from(chunk))
+    }
+
+    impl<E: Error> LimitStreamError<E> {
+        fn is_limit_exceeded(&self) -> bool {
+            match self {
+                LimitStreamError::LimitExceeded => true,
+                _ => false,
+            }
+        }
+    }
+}

--- a/crates/interledger-http/src/server.rs
+++ b/crates/interledger-http/src/server.rs
@@ -1,3 +1,4 @@
+use super::limit_stream::LimitStream;
 use super::HttpStore;
 use bytes::BytesMut;
 use futures::{
@@ -9,6 +10,9 @@ use hyper::{
 };
 use interledger_packet::{Fulfill, Prepare, Reject};
 use interledger_service::*;
+
+/// Max message size that is allowed to transfer from a request or a message.
+pub const MAX_MESSAGE_SIZE: usize = 40000;
 
 /// A Hyper::Service that parses incoming ILP-Over-HTTP requests, validates the authorization,
 /// and passes the request to an IncomingService handler.
@@ -61,14 +65,16 @@ where
         let mut next = self.next.clone();
         self.check_authorization(&request)
             .and_then(|from_account| {
-                parse_prepare_from_request(request).and_then(move |prepare| {
-                    // Call the inner ILP service
-                    next.handle_request(IncomingRequest {
-                        from: from_account,
-                        prepare,
-                    })
-                    .then(ilp_response_to_http_response)
-                })
+                parse_prepare_from_request(request, Some(MAX_MESSAGE_SIZE)).and_then(
+                    move |prepare| {
+                        // Call the inner ILP service
+                        next.handle_request(IncomingRequest {
+                            from: from_account,
+                            prepare,
+                        })
+                        .then(ilp_response_to_http_response)
+                    },
+                )
             })
             .then(|result| match result {
                 Ok(response) => Ok(response),
@@ -94,18 +100,23 @@ where
 
 fn parse_prepare_from_request(
     request: Request<Body>,
+    max_message_size: Option<usize>,
 ) -> impl Future<Item = Prepare, Error = Response<Body>> + 'static {
-    request
-        .into_body()
+    LimitStream::new(max_message_size, request.into_body())
         .concat2()
-        .map_err(|_err| Response::builder().status(500).body(Body::empty()).unwrap())
+        .map_err(|err| {
+            eprintln!("Concatenating stream failed: {:?}", err);
+            Response::builder().status(500).body(Body::empty()).unwrap()
+        })
         .and_then(|body| {
             let bytes = body.into_bytes().try_mut().unwrap_or_else(|bytes| {
                 debug!("Copying bytes from incoming HTTP request into Prepare packet");
                 BytesMut::from(bytes)
             });
-            Prepare::try_from(bytes)
-                .map_err(|_err| Response::builder().status(400).body(Body::empty()).unwrap())
+            Prepare::try_from(bytes).map_err(|err| {
+                eprintln!("Parsing prepare packet failed: {:?}", err);
+                Response::builder().status(400).body(Body::empty()).unwrap()
+            })
         })
 }
 
@@ -121,4 +132,100 @@ fn ilp_response_to_http_response(
         .header("content-type", "application/octet-stream")
         .body(bytes.freeze().into())
         .unwrap())
+}
+
+#[cfg(test)]
+mod test_limit_stream {
+    use super::*;
+    use interledger_packet::PrepareBuilder;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn test_parse_prepare_from_request_less() {
+        // just ensuring that body size is more than default limit of MAX_MESSAGE_SIZE
+        let prepare_data = PrepareBuilder {
+            amount: 1,
+            destination: b"test.prepare",
+            execution_condition: &[0; 32],
+            expires_at: SystemTime::now() + Duration::from_secs(30),
+            data: &[0; MAX_MESSAGE_SIZE],
+        };
+        let prepare = prepare_data.clone().build();
+        let body_size = BytesMut::from(prepare.clone()).len();
+        let parsed_prepare = make_prepare_and_parse(prepare_data, Some(body_size)).unwrap();
+
+        assert_eq!(prepare.amount(), parsed_prepare.amount());
+        assert_eq!(prepare.destination(), parsed_prepare.destination());
+        assert_eq!(
+            prepare.execution_condition(),
+            parsed_prepare.execution_condition()
+        );
+        assert_eq!(
+            get_millis_from_unix_epoch(prepare.expires_at()),
+            get_millis_from_unix_epoch(parsed_prepare.expires_at())
+        );
+        assert_eq!(prepare.data(), parsed_prepare.data());
+    }
+
+    #[test]
+    fn test_parse_prepare_from_request_more() {
+        let prepare_data = PrepareBuilder {
+            amount: 1,
+            destination: b"test.prepare",
+            execution_condition: &[0; 32],
+            expires_at: SystemTime::now() + Duration::from_secs(30),
+            data: &[0; 0],
+        };
+        let prepare = make_prepare_and_parse(prepare_data, Some(1));
+        assert!(prepare.is_err());
+    }
+
+    #[test]
+    fn test_parse_prepare_from_request_no_limit() {
+        let prepare_data = PrepareBuilder {
+            amount: 1,
+            destination: b"test.prepare",
+            execution_condition: &[0; 32],
+            expires_at: SystemTime::now() + Duration::from_secs(30),
+            data: &[0; MAX_MESSAGE_SIZE],
+        };
+        let prepare = prepare_data.clone().build();
+        let parsed_prepare = make_prepare_and_parse(prepare_data, None).unwrap();
+
+        assert_eq!(prepare.amount(), parsed_prepare.amount());
+        assert_eq!(prepare.destination(), parsed_prepare.destination());
+        assert_eq!(
+            prepare.execution_condition(),
+            parsed_prepare.execution_condition()
+        );
+        assert_eq!(
+            get_millis_from_unix_epoch(prepare.expires_at()),
+            get_millis_from_unix_epoch(parsed_prepare.expires_at())
+        );
+        assert_eq!(prepare.data(), parsed_prepare.data());
+    }
+
+    fn make_prepare_and_parse(
+        prepare_data: PrepareBuilder,
+        max_message_size: Option<usize>,
+    ) -> Result<Prepare, Response<Body>> {
+        let prepare = prepare_data.build();
+        let prepare_bytes = BytesMut::from(prepare).freeze();
+        println!("prepare_bytes: {:?}", prepare_bytes);
+
+        let body: Body = hyper::Body::from(prepare_bytes);
+        let request = hyper::Request::builder()
+            .header("content-type", "application/octet-stream")
+            .body(body)
+            .unwrap();
+
+        parse_prepare_from_request(request, max_message_size).wait()
+    }
+
+    fn get_millis_from_unix_epoch(system_time: SystemTime) -> u128 {
+        system_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    }
 }


### PR DESCRIPTION
- Fix https://github.com/emschwartz/interledger-rs/issues/37
- Previous discussions are here: https://github.com/emschwartz/interledger-rs/pull/61
- Prevents from sending huge amount of data through HTTP requests using limit_stream.
  - max message size is defined in `interledger-http` and `interledger-btp` uses it.
- `limit_stream` is originally from [interledger-relay](https://github.com/coilhq/interledger-relay) by @sentientwaffle