### PR TITLE
Settlement Engine Framework and Ethereum Ledger Settlement Engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,20 @@ jobs:
             sudo apt-get -t stretch-backports install redis-server
             redis-server --version
       - run:
+          name: Install node and ganache
+          command: |
+              curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+              source ~/.nvm/nvm.sh
+              nvm install node
+              npm install -g ganache-cli
+      - run:
           name: Build
           command: cargo build --all-features --all-targets
       - run:
           name: Test
-          command: cargo test --all --all-features
+          command: |
+              source ~/.nvm/nvm.sh # load node paths for ganache-cli
+              cargo test --all --all-features
           environment:
             RUST_BACKTRACE: "1"
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,8 @@ members = [
   "./crates/interledger-store-memory",
   "./crates/interledger-store-redis",
   "./crates/interledger-stream",
+  "./crates/interledger-settlement-engines",
 ]
+
+[profile.dev]
+codegen-units = 1

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -24,6 +24,9 @@ log = "0.4.6"
 serde = "1.0.89"
 serde_json = "1.0.39"
 tower-web = "0.3.7"
+reqwest = "0.9.18"
+url = "1.7.2"
+tokio-retry = "0.2.0"
 
 [badges]
 circle-ci = { repository = "emschwartz/interledger-rs" }

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -72,7 +72,6 @@ pub struct AccountDetails {
     pub packets_per_minute_limit: Option<u32>,
     pub settlement_engine_url: Option<String>,
     pub settlement_engine_asset_scale: Option<u8>,
-    pub settlement_engine_ilp_address: Option<Address>,
 }
 
 pub struct NodeApi<S, I> {

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/emschwartz/interledger-rs"
 [dependencies]
 futures = "0.1.25"
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }
+serde = "1.0.94"

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -36,6 +36,8 @@ use std::{
     str::FromStr,
 };
 
+use serde::Serialize;
+
 /// The base trait that Account types from other Services extend.
 /// This trait only assumes that the account has an ID that can be compared with others.
 ///
@@ -43,7 +45,7 @@ use std::{
 /// Store implementations will implement these Account traits for a concrete type that
 /// they will load from the database.
 pub trait Account: Clone + Send + Sized + Debug {
-    type AccountId: Eq + Hash + Debug + Display + Default + FromStr + Send + Sync + Copy;
+    type AccountId: Eq + Hash + Debug + Display + Default + FromStr + Send + Sync + Copy + Serialize;
 
     fn id(&self) -> Self::AccountId;
 }

--- a/crates/interledger-settlement-engines/Cargo.toml
+++ b/crates/interledger-settlement-engines/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "interledger-settlement-engines"
+version = "0.1.0"
+authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+edition = "2018"
+
+[dependencies]
+tower-web = "0.3.7"
+hex = "0.3.2"
+ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign", branch = "exported-web3" }
+log = "0.4.6"
+tokio = "0.1.21"
+hyper = "0.12.31"
+futures = "0.1.25"
+interledger-service = { path = "../interledger-service", version = "0.2.1" }
+interledger-settlement = { path = "../interledger-settlement", version = "0.1.0" }
+interledger-service-util = { path = "../interledger-service-util", version = "0.2.1" }
+interledger-store-redis = { path = "../interledger-store-redis", version = "0.2.1" }
+interledger-ildcp = { path = "../interledger-ildcp", version = "0.2.1" }
+ethabi = "6.1.0"
+serde = "1.0.91"
+serde_json = "1.0.40"
+json = "0.11.14"
+bytes = "0.4.12"
+ring = "0.14.6"
+tokio-executor = "0.1.8"
+url = "1.7.2"
+reqwest = "0.9.18"
+env_logger = "0.6.2"
+uuid = { version = "0.7.4", features = ["serde", "v4"]  }
+tokio-retry = "0.2.0"
+redis = { version = "0.10.0", features = [ "with-unix-sockets" ] }
+hashbrown = "0.5.0"
+http = "0.1.17"
+clap = "2.32.0"
+clarity = { git =  "https://github.com/gakonst/clarity" }
+sha3 = "0.8.2"
+
+[dev-dependencies]
+lazy_static = "1.3"
+mockito = "0.18.0"
+parking_lot = "0.9.0"
+net2 = "0.2.33"
+os_type = "2.2.0"
+rand = "0.7.0"

--- a/crates/interledger-settlement-engines/README.md
+++ b/crates/interledger-settlement-engines/README.md
@@ -1,0 +1,5 @@
+# Settlement Engines Crate
+
+## Implemented Engines
+
+- Ethereum

--- a/crates/interledger-settlement-engines/src/api.rs
+++ b/crates/interledger-settlement-engines/src/api.rs
@@ -1,0 +1,401 @@
+use crate::ApiResponse;
+use crate::Quantity;
+use crate::SettlementEngine;
+use bytes::Bytes;
+use futures::{
+    future::{err, ok, Either},
+    Future,
+};
+use hyper::{Response, StatusCode};
+use interledger_settlement::{IdempotentData, IdempotentStore};
+use log::error;
+use ring::digest::{digest, SHA256};
+use tokio::executor::spawn;
+use tower_web::{net::ConnectionStream, ServiceBuilder};
+
+/// # Settlement Engine API
+///
+/// Tower_Web service which exposes settlement related endpoints as described in RFC536,
+/// See [forum discussion](https://forum.interledger.org/t/settlement-architecture/545) for more context.
+/// All endpoints are idempotent.
+pub struct SettlementEngineApi<E, S> {
+    engine: E,
+    store: S,
+}
+
+impl_web! {
+    impl<E, S> SettlementEngineApi<E, S>
+    where
+        E: SettlementEngine + Clone + Send + Sync + 'static,
+        S: IdempotentStore + Clone + Send + Sync + 'static,
+    {
+        /// Create a new API service by providing it with a field that
+        /// implements the `SettlementEngine` trait
+        pub fn new(engine: E, store: S) -> Self {
+            Self { engine, store }
+        }
+
+        #[post("/accounts/:account_id/settlement")]
+        /// Forwards the data to the API engine's `send_money` function.
+        /// Endpoint: POST /accounts/:id/settlement
+        fn execute_settlement(&self, account_id: String, body: Quantity, idempotency_key: Option<String>) -> impl Future<Item = Response<String>, Error = Response<String>> {
+            // check idempotency
+            let input = format!("{}{:?}", account_id, body);
+            let input_hash = get_hash_of(input.as_ref());
+            let account_id = account_id.clone();
+            let engine = self.engine.clone();
+            let f = move || engine.send_money(account_id, body);
+            self.make_idempotent_call(f, input_hash, idempotency_key)
+        }
+
+        #[post("/accounts/:account_id/messages")]
+        /// Forwards the data to the API engine's `receive_message` function.
+        /// Endpoint: POST /accounts/:id/messages
+        fn receive_message(&self, account_id: String, body: Vec<u8>, idempotency_key: Option<String>) -> impl Future<Item = Response<String>, Error = Response<String>> {
+            let input = format!("{}{:?}", account_id, body);
+            let input_hash = get_hash_of(input.as_ref());
+            let account_id = account_id.clone();
+            let engine = self.engine.clone();
+            let f = move || engine.receive_message(account_id, body);
+            self.make_idempotent_call(f, input_hash, idempotency_key)
+        }
+
+        #[post("/accounts/:account_id")]
+        /// Forwards the data to the API engine's `create_account` function.
+        /// Endpoint: POST /accounts/:id/
+        fn create_account(&self, account_id: String, idempotency_key: Option<String>) -> impl Future<Item = Response<String>, Error = Response<String>> {
+            let input_hash = get_hash_of(account_id.as_ref());
+            let engine = self.engine.clone();
+            let f = move || engine.create_account(account_id);
+            self.make_idempotent_call(f, input_hash, idempotency_key)
+        }
+
+        // Helper function that returns any idempotent data that corresponds to a
+        // provided idempotency key. It fails if the hash of the input that
+        // generated the idempotent data does not match the hash of the provided input.
+        fn check_idempotency(
+            &self,
+            idempotency_key: String,
+            input_hash: [u8; 32],
+        ) -> impl Future<Item = (StatusCode, Bytes), Error = String> {
+            self.store
+                .load_idempotent_data(idempotency_key.clone())
+                .map_err(move |_| {
+                    let error_msg = "Couldn' load idempotent data".to_owned();
+                    error!("{}", error_msg);
+                    error_msg
+                })
+                .and_then(move |ret: IdempotentData| {
+                    if ret.2 == input_hash {
+                        Ok((ret.0, ret.1))
+                    } else {
+                        Ok((StatusCode::from_u16(409).unwrap(), Bytes::from(&b"Provided idempotency key is tied to other input"[..])))
+                    }
+                })
+        }
+
+        fn make_idempotent_call<F>(&self, f: F, input_hash: [u8; 32], idempotency_key: Option<String>) -> impl Future<Item = Response<String>, Error = Response<String>>
+        where F: FnOnce() -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+            let store = self.store.clone();
+            if let Some(idempotency_key) = idempotency_key {
+                // If there an idempotency key was provided, check idempotency
+                // and the key was not present or conflicting with an existing
+                // key, perform the call and save the idempotent return data
+                Either::A(
+                    self.check_idempotency(idempotency_key.clone(), input_hash)
+                    .map_err(|err| Response::builder().status(502).body(err).unwrap())
+                    .then(move |ret: Result<(StatusCode, Bytes), Response<String>>| {
+                        if let Ok(ret) = ret {
+                            let resp = Response::builder().status(ret.0).body(String::from_utf8_lossy(&ret.1).to_string()).unwrap();
+                            if ret.0.is_success() {
+                                return Either::A(Either::A(ok(resp)))
+                            } else {
+                                return Either::A(Either::B(err(resp)))
+                            }
+                        } else {
+                            Either::B(
+                                f()
+                                .map_err({let store = store.clone(); let idempotency_key = idempotency_key.clone(); move |ret: (StatusCode, String)| {
+                                    spawn(store.save_idempotent_data(idempotency_key, input_hash, ret.0, Bytes::from(ret.1.clone())));
+                                    Response::builder().status(ret.0).body(ret.1).unwrap()
+                                }})
+                                .and_then(move |ret: (StatusCode, String)| {
+                                    store.save_idempotent_data(idempotency_key, input_hash, ret.0, Bytes::from(ret.1.clone()))
+                                    .map_err({let ret = ret.clone(); move |_| {
+                                        Response::builder().status(ret.0).body(ret.1).unwrap()
+                                    }}).and_then(move |_| {
+                                        Ok(Response::builder().status(ret.0).body(ret.1).unwrap())
+                                    })
+                                })
+                            )
+                        }
+                    }))
+            } else {
+                // otherwise just make the call without any idempotency saves
+                Either::B(
+                    f()
+                    .map_err(move |ret: (StatusCode, String)| {
+                        Response::builder().status(ret.0).body(ret.1).unwrap()
+                    })
+                    .and_then(move |ret: (StatusCode, String)| {
+                        Ok(Response::builder().status(ret.0).body(ret.1).unwrap())
+                    })
+                )
+            }
+
+        }
+    }
+}
+
+fn get_hash_of(preimage: &[u8]) -> [u8; 32] {
+    let mut hash = [0; 32];
+    hash.copy_from_slice(digest(&SHA256, preimage).as_ref());
+    hash
+}
+
+impl<E, S> SettlementEngineApi<E, S>
+where
+    E: SettlementEngine + Clone + Send + Sync + 'static,
+    S: IdempotentStore + Clone + Send + Sync + 'static,
+{
+    /// Serves the API
+    /// Example:
+    /// ```rust,compile_fail
+    /// let settlement_api = SettlementEngineApi::new(engine, store);
+    /// let listener = TcpListener::bind(&http_address)
+    ///     .expect("Unable to bind to HTTP address");
+    /// tokio::spawn(api.serve(listener.incoming()));
+    /// ```
+    pub fn serve<I>(self, incoming: I) -> impl Future<Item = (), Error = ()>
+    where
+        I: ConnectionStream,
+        I::Item: Send + 'static,
+    {
+        ServiceBuilder::new().resource(self).serve(incoming)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::engines::ethereum_ledger::fixtures::ALICE;
+    use super::super::engines::ethereum_ledger::test_helpers::test_store;
+    use super::super::stores::test_helpers::store_helpers::block_on;
+    use lazy_static::lazy_static;
+
+    use super::*;
+    use crate::ApiResponse;
+
+    #[derive(Clone)]
+    struct TestEngine;
+
+    lazy_static! {
+        pub static ref IDEMPOTENCY: String = String::from("abcd01234");
+    }
+
+    impl SettlementEngine for TestEngine {
+        fn send_money(
+            &self,
+            _account_id: String,
+            _money: Quantity,
+        ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+            Box::new(ok((StatusCode::from_u16(200).unwrap(), "OK".to_string())))
+        }
+
+        fn receive_message(
+            &self,
+            _account_id: String,
+            _message: Vec<u8>,
+        ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+            Box::new(ok((
+                StatusCode::from_u16(200).unwrap(),
+                "RECEIVED".to_string(),
+            )))
+        }
+
+        fn create_account(
+            &self,
+            _account_id: String,
+        ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+            Box::new(ok((
+                StatusCode::from_u16(201).unwrap(),
+                "CREATED".to_string(),
+            )))
+        }
+    }
+
+    #[test]
+    fn idempotent_execute_settlement() {
+        let store = test_store(ALICE.clone(), false, false, false);
+        let engine = TestEngine;;
+        let api = SettlementEngineApi {
+            store: store.clone(),
+            engine,
+        };
+
+        let ret: Response<_> = block_on(api.execute_settlement(
+            "1".to_owned(),
+            Quantity { amount: 100 },
+            Some(IDEMPOTENCY.clone()),
+        ))
+        .unwrap();
+        assert_eq!(ret.status().as_u16(), 200);
+        assert_eq!(ret.body(), "OK");
+
+        // is idempotent
+        let ret: Response<_> = block_on(api.execute_settlement(
+            "1".to_owned(),
+            Quantity { amount: 100 },
+            Some(IDEMPOTENCY.clone()),
+        ))
+        .unwrap();
+        assert_eq!(ret.status().as_u16(), 200);
+        assert_eq!(ret.body(), "OK");
+
+        // // fails with different id and same data
+        let ret: Response<_> = block_on(api.execute_settlement(
+            "42".to_owned(),
+            Quantity { amount: 100 },
+            Some(IDEMPOTENCY.clone()),
+        ))
+        .unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        // fails with same id and different data
+        let ret: Response<_> = block_on(api.execute_settlement(
+            "1".to_string(),
+            Quantity { amount: 42 },
+            Some(IDEMPOTENCY.clone()),
+        ))
+        .unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        // fails with different id and different data
+        let ret: Response<_> = block_on(api.execute_settlement(
+            "42".to_string(),
+            Quantity { amount: 42 },
+            Some(IDEMPOTENCY.clone()),
+        ))
+        .unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        let cache = store.cache.read();
+        let cached_data = cache.get(&IDEMPOTENCY.to_string()).unwrap();
+
+        let cache_hits = store.cache_hits.read();
+        assert_eq!(*cache_hits, 4);
+        assert_eq!(cached_data.0, 200);
+        assert_eq!(cached_data.1, "OK".to_string());
+    }
+
+    #[test]
+    fn idempotent_receive_message() {
+        let store = test_store(ALICE.clone(), false, false, false);
+        let engine = TestEngine;;
+        let api = SettlementEngineApi {
+            store: store.clone(),
+            engine,
+        };
+
+        let ret: Response<_> =
+            block_on(api.receive_message("1".to_owned(), vec![0], Some(IDEMPOTENCY.clone())))
+                .unwrap();
+        assert_eq!(ret.status().as_u16(), 200);
+        assert_eq!(ret.body(), "RECEIVED");
+
+        // is idempotent
+        let ret: Response<_> =
+            block_on(api.receive_message("1".to_owned(), vec![0], Some(IDEMPOTENCY.clone())))
+                .unwrap();
+        assert_eq!(ret.status().as_u16(), 200);
+        assert_eq!(ret.body(), "RECEIVED");
+
+        // // fails with different id and same data
+        let ret: Response<_> =
+            block_on(api.receive_message("42".to_owned(), vec![0], Some(IDEMPOTENCY.clone())))
+                .unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        // fails with same id and different data
+        let ret: Response<_> =
+            block_on(api.receive_message("1".to_string(), vec![1], Some(IDEMPOTENCY.clone())))
+                .unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        // fails with different id and different data
+        let ret: Response<_> =
+            block_on(api.receive_message("42".to_string(), vec![1], Some(IDEMPOTENCY.clone())))
+                .unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        let cache = store.cache.read();
+        let cached_data = cache.get(&IDEMPOTENCY.to_string()).unwrap();
+
+        let cache_hits = store.cache_hits.read();
+        assert_eq!(*cache_hits, 4);
+        assert_eq!(cached_data.0, 200);
+        assert_eq!(cached_data.1, "RECEIVED".to_string());
+    }
+
+    #[test]
+    fn idempotent_create_account() {
+        let store = test_store(ALICE.clone(), false, false, false);
+        let engine = TestEngine;;
+        let api = SettlementEngineApi {
+            store: store.clone(),
+            engine,
+        };
+
+        let ret: Response<_> =
+            block_on(api.create_account("1".to_owned(), Some(IDEMPOTENCY.clone()))).unwrap();
+        assert_eq!(ret.status().as_u16(), 201);
+        assert_eq!(ret.body(), "CREATED");
+
+        // is idempotent
+        let ret: Response<_> =
+            block_on(api.create_account("1".to_owned(), Some(IDEMPOTENCY.clone()))).unwrap();
+        assert_eq!(ret.status().as_u16(), 201);
+        assert_eq!(ret.body(), "CREATED");
+
+        // fails with different id
+        let ret: Response<_> =
+            block_on(api.create_account("42".to_owned(), Some(IDEMPOTENCY.clone()))).unwrap_err();
+        assert_eq!(ret.status().as_u16(), 409);
+        assert_eq!(
+            ret.body(),
+            "Provided idempotency key is tied to other input"
+        );
+
+        let cache = store.cache.read();
+        let cached_data = cache.get(&IDEMPOTENCY.to_string()).unwrap();
+
+        let cache_hits = store.cache_hits.read();
+        assert_eq!(*cache_hits, 2);
+        assert_eq!(cached_data.0, 201);
+        assert_eq!(cached_data.1, "CREATED".to_string());
+    }
+
+}

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
@@ -1,0 +1,943 @@
+use super::types::{Addresses, EthereumAccount, EthereumLedgerTxSigner, EthereumStore};
+use super::utils::{filter_transfer_logs, make_tx, sent_to_us, ERC20Transfer};
+use clarity::Signature;
+use log::{debug, error, trace};
+use sha3::{Digest, Keccak256 as Sha3};
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+use ethereum_tx_sign::web3::{
+    api::Web3,
+    futures::future::{err, join_all, ok, result, Either, Future},
+    futures::stream::Stream,
+    transports::Http,
+    types::{Address, BlockNumber, CallRequest, TransactionId, H256, U256},
+};
+use hyper::StatusCode;
+use reqwest::r#async::{Client, Response as HttpResponse};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    marker::PhantomData,
+    str::FromStr,
+    time::{Duration, Instant},
+};
+use tokio::timer::Interval;
+use tokio_retry::{strategy::ExponentialBackoff, Retry};
+use url::Url;
+use uuid::Uuid;
+
+use crate::{ApiResponse, Quantity, SettlementEngine};
+
+const MAX_RETRIES: usize = 10;
+const ETH_CREATE_ACCOUNT_PREFIX: &[u8] = b"ilp-ethl-create-account-message";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PaymentDetailsResponse {
+    to: Addresses,
+    sig: Signature,
+}
+
+impl PaymentDetailsResponse {
+    fn new(to: Addresses, sig: Signature) -> Self {
+        PaymentDetailsResponse { to, sig }
+    }
+}
+
+/// # Ethereum Ledger Settlement Engine
+///
+/// Settlement Engine compliant to [RFC536](https://github.com/interledger/rfcs/pull/536/)
+///
+/// The engine connects to an Ethereum node (over HTTP) as well as the connector. Its
+/// functions are exposed via the Settlement Engine API.
+///
+/// It requires a `confirmations` security parameter which is used to ensure
+/// that all transactions that get sent to the connector have sufficient
+/// confirmations (suggested value: >6)
+///
+/// All settlements made with this engine make on-chain Layer 1 Ethereum
+/// transactions. This engine DOES NOT support payment channels.
+#[derive(Debug, Clone)]
+pub struct EthereumLedgerSettlementEngine<S, Si, A> {
+    store: S,
+    signer: Si,
+    account_type: PhantomData<A>,
+
+    // Configuration data
+    web3: Web3<Http>,
+    address: Addresses,
+    chain_id: u8,
+    confirmations: u8,
+    poll_frequency: Duration,
+    connector_url: Url,
+}
+
+pub struct EthereumLedgerSettlementEngineBuilder<'a, S, Si, A> {
+    store: S,
+    signer: Si,
+
+    /// Ethereum Endpoint, default localhost:8545
+    ethereum_endpoint: Option<&'a str>,
+    chain_id: Option<u8>,
+    confirmations: Option<u8>,
+    poll_frequency: Option<Duration>,
+    connector_url: Option<Url>,
+    token_address: Option<Address>,
+    watch_incoming: bool,
+    account_type: PhantomData<A>,
+}
+
+impl<'a, S, Si, A> EthereumLedgerSettlementEngineBuilder<'a, S, Si, A>
+where
+    S: EthereumStore<Account = A> + Clone + Send + Sync + 'static,
+    Si: EthereumLedgerTxSigner + Clone + Send + Sync + 'static,
+    A: EthereumAccount + Send + Sync + 'static,
+{
+    pub fn new(store: S, signer: Si) -> Self {
+        Self {
+            store,
+            signer,
+            ethereum_endpoint: None,
+            chain_id: None,
+            confirmations: None,
+            poll_frequency: None,
+            connector_url: None,
+            token_address: None,
+            watch_incoming: false,
+            account_type: PhantomData,
+        }
+    }
+
+    pub fn token_address(&mut self, token_address: Option<Address>) -> &mut Self {
+        self.token_address = token_address;
+        self
+    }
+
+    pub fn ethereum_endpoint(&mut self, endpoint: &'a str) -> &mut Self {
+        self.ethereum_endpoint = Some(endpoint);
+        self
+    }
+
+    pub fn chain_id(&mut self, chain_id: u8) -> &mut Self {
+        self.chain_id = Some(chain_id);
+        self
+    }
+
+    pub fn confirmations(&mut self, confirmations: u8) -> &mut Self {
+        self.confirmations = Some(confirmations);
+        self
+    }
+
+    pub fn poll_frequency(&mut self, poll_frequency: u64) -> &mut Self {
+        self.poll_frequency = Some(Duration::from_millis(poll_frequency));
+        self
+    }
+
+    pub fn watch_incoming(&mut self, watch_incoming: bool) -> &mut Self {
+        self.watch_incoming = watch_incoming;
+        self
+    }
+
+    pub fn connector_url(&mut self, connector_url: &'a str) -> &mut Self {
+        self.connector_url = Some(connector_url.parse().unwrap());
+        self
+    }
+
+    pub fn connect(&self) -> EthereumLedgerSettlementEngine<S, Si, A> {
+        let ethereum_endpoint = if let Some(ref ethereum_endpoint) = self.ethereum_endpoint {
+            &ethereum_endpoint
+        } else {
+            "http://localhost:8545"
+        };
+        let chain_id = if let Some(chain_id) = self.chain_id {
+            chain_id
+        } else {
+            1
+        };
+        let connector_url = if let Some(connector_url) = self.connector_url.clone() {
+            connector_url
+        } else {
+            "http://localhost:7771".parse().unwrap()
+        };
+        let confirmations = if let Some(confirmations) = self.confirmations {
+            confirmations
+        } else {
+            6
+        };
+        let poll_frequency = if let Some(poll_frequency) = self.poll_frequency {
+            poll_frequency
+        } else {
+            Duration::from_secs(5)
+        };
+
+        let (eloop, transport) = Http::new(ethereum_endpoint).unwrap();
+        eloop.into_remote();
+        let web3 = Web3::new(transport);
+        let address = Addresses {
+            own_address: self.signer.address(),
+            token_address: self.token_address,
+        };
+
+        let engine = EthereumLedgerSettlementEngine {
+            web3,
+            store: self.store.clone(),
+            signer: self.signer.clone(),
+            address,
+            chain_id,
+            confirmations,
+            poll_frequency,
+            connector_url,
+            account_type: PhantomData,
+        };
+        if self.watch_incoming {
+            engine.notify_connector_on_incoming_settlement();
+        }
+        engine
+    }
+}
+
+impl<S, Si, A> EthereumLedgerSettlementEngine<S, Si, A>
+where
+    S: EthereumStore<Account = A> + Clone + Send + Sync + 'static,
+    Si: EthereumLedgerTxSigner + Clone + Send + Sync + 'static,
+    A: EthereumAccount + Send + Sync + 'static,
+{
+    /// Periodically spawns a job every `self.poll_frequency` that notifies the
+    /// Settlement Engine's connectors about transactions which are sent to the
+    /// engine's address.
+    pub fn notify_connector_on_incoming_settlement(&self) {
+        let _self = self.clone();
+        let interval = self.poll_frequency;
+        let address = self.address;
+        debug!(
+            "[{:?}] settlement engine service for listening to incoming settlements. Interval: {:?}",
+            address, interval,
+        );
+        std::thread::spawn(move || {
+            tokio::run(
+                Interval::new(Instant::now(), interval)
+                    .for_each(move |instant| {
+                        debug!(
+                            "[{:?}] Getting settlement data from the blockchain; instant={:?}",
+                            address, instant
+                        );
+                        tokio::spawn(_self.handle_received_transactions());
+                        Ok(())
+                    })
+                    .map_err(|e| panic!("interval errored; err={:?}", e)),
+            );
+        });
+    }
+
+    /// Routine for notifying the connector about incoming transactions.
+    /// Algorithm (heavily unoptimized):
+    /// 1. Fetch the last observed block number
+    /// 2. Fetch the current block number from Ethereum
+    /// 3. Fetch all blocks since the last observed one,
+    ///    until $(current block number - confirmations), where $confirmations
+    ///    is a security parameter to be safe against block reorgs.
+    /// 4. For each block (in parallel):
+    ///     For each transaction (in parallel):
+    ///     1. Skip if it is not sent to our address or have 0 value.
+    ///     2. Fetch the id that matches its sender from the store
+    ///     3. Notify the connector about it by making a POST request to the connector's
+    ///        /accounts/$id/settlement endpoint with transaction's value as the
+    ///        body. This call is retried if it fails.
+    /// 5. Save (current block number - confirmations) to be used as
+    ///    last observed data for the next call of this function.
+    // Optimization: This will make 1 settlement API request to
+    // the connector per transaction that comes to us. Since
+    // we're scanning across multiple blocks, we want to
+    // optimize it so that: it gathers a mapping of
+    // (accountId=>amount) across all transactions and blocks, and
+    // only makes 1 transaction per accountId with the
+    // appropriate amount.
+    pub fn handle_received_transactions(&self) -> impl Future<Item = (), Error = ()> + Send {
+        let confirmations = self.confirmations;
+        let web3 = self.web3.clone();
+        let store = self.store.clone();
+        let store_clone = self.store.clone();
+        let self_clone = self.clone();
+        let self_clone2 = self.clone();
+        let our_address = self.address.own_address;
+        let token_address = self.address.token_address;
+
+        // get the current block number
+        web3.eth()
+            .block_number()
+            .map_err(move |err| error!("Could not fetch current block number {:?}", err))
+            .and_then(move |current_block| {
+                debug!("Current block {}", current_block);
+                // get the safe number of blocks to avoid reorgs
+                let fetch_until = current_block - confirmations;
+                // U256 does not implement IntoFuture so we must wrap it
+                Ok((Ok(fetch_until), store.load_recently_observed_block()))
+            })
+            .flatten()
+            .and_then(move |(fetch_until, last_observed_block)| {
+                debug!(
+                    "Will fetch txs from block {} until {}",
+                    last_observed_block, fetch_until
+                );
+
+                let notify_all_txs_fut = if let Some(token_address) = token_address {
+                    debug!("Settling for ERC20 transactions");
+                    // get all erc20 transactions
+                    let notify_all_erc20_txs_fut = filter_transfer_logs(
+                        web3.clone(),
+                        token_address,
+                        None,
+                        Some(our_address),
+                        BlockNumber::Number(last_observed_block.low_u64()),
+                        BlockNumber::Number(fetch_until.low_u64()),
+                    )
+                    .and_then(move |transfers: Vec<ERC20Transfer>| {
+                        // map each incoming erc20 transactions to an outgoing
+                        // notification to the connector
+                        join_all(transfers.into_iter().map(move |transfer| {
+                            self_clone2.notify_erc20_transfer(transfer, token_address)
+                        }))
+                    });
+
+                    // combine all erc20 futures for that range of blocks
+                    Either::A(notify_all_erc20_txs_fut)
+                } else {
+                    debug!("Settling for ETH transactions");
+                    let checked_blocks = last_observed_block.low_u64()..=fetch_until.low_u64();
+                    // for each block create a future which will notify the
+                    // connector about all the transactions in that block that are sent to our account
+                    let notify_eth_txs_fut = checked_blocks
+                        .map(move |block_num| self_clone.notify_eth_txs_in_block(block_num));
+
+                    // combine all the futures for that range of blocks
+                    Either::B(join_all(notify_eth_txs_fut))
+                };
+
+                notify_all_txs_fut.and_then(move |ret| {
+                    debug!("Transactions settled {:?}", ret);
+                    // now that all transactions have been processed successfully, we
+                    // can save `fetch_until` as the latest observed block
+                    store_clone.save_recently_observed_block(fetch_until)
+                })
+            })
+    }
+
+    /// Submits an ERC20 transfer object's data to the connector
+    // todo: Try combining the body of this function with `notify_eth_transfer`
+    fn notify_erc20_transfer(
+        &self,
+        transfer: ERC20Transfer,
+        token_address: Address,
+    ) -> impl Future<Item = (), Error = ()> {
+        let store = self.store.clone();
+        let tx_hash = transfer.tx_hash;
+        let self_clone = self.clone();
+        let addr = Addresses {
+            own_address: transfer.from,
+            token_address: Some(token_address),
+        };
+        let amount = transfer.amount;
+        store
+            .check_if_tx_processed(tx_hash)
+            .map_err(move |_| error!("Error when querying store about transaction: {:?}", tx_hash))
+            .and_then(move |processed| {
+                if !processed {
+                    Either::A(
+                        store
+                            .load_account_id_from_address(addr)
+                            .and_then(move |id| {
+                                self_clone.notify_connector(
+                                    id.to_string(),
+                                    amount.low_u64(),
+                                    tx_hash,
+                                )
+                            })
+                            .and_then(move |_| {
+                                // only save the transaction hash if the connector
+                                // was successfully notified
+                                store.mark_tx_processed(tx_hash)
+                            }),
+                    )
+                } else {
+                    Either::B(ok(())) // return an empty future otherwise since we want to skip this transaction
+                }
+            })
+    }
+
+    fn notify_eth_txs_in_block(&self, block_number: u64) -> impl Future<Item = (), Error = ()> {
+        debug!("Getting txs for block {}", block_number);
+        let self_clone = self.clone();
+        // Get the block at `block_number`
+        self.web3
+            .eth()
+            .block(BlockNumber::Number(block_number).into())
+            .map_err(move |err| error!("Got error while getting block {}: {:?}", block_number, err))
+            .and_then(move |maybe_block| {
+                // Error out if the block was not found (unlikely to occur since we're only
+                // calling this for past blocks)
+                if let Some(block) = maybe_block {
+                    ok(block)
+                } else {
+                    err(())
+                }
+            })
+            .and_then(move |block| {
+                // for each transaction inside the block, submit it to the
+                // connector if it was sent to us
+                let submit_txs_to_connector_future = block
+                    .transactions
+                    .into_iter()
+                    .map(move |tx_hash| self_clone.notify_eth_transfer(tx_hash));
+
+                // combine all the futures for that block's transactions
+                join_all(submit_txs_to_connector_future)
+            })
+            .and_then(move |_res| {
+                debug!(
+                    "Successfully logged transactions in block: {:?}",
+                    block_number
+                );
+                ok(())
+            })
+    }
+
+    fn notify_eth_transfer(&self, tx_hash: H256) -> impl Future<Item = (), Error = ()> {
+        let our_address = self.address.own_address;
+        let web3 = self.web3.clone();
+        let store = self.store.clone();
+        let self_clone = self.clone();
+        // Skip transactions which have already been processed by the connector
+        store.check_if_tx_processed(tx_hash)
+        .map_err(move |_| error!("Error when querying store about transaction: {:?}", tx_hash))
+        .and_then(move |processed| {
+            if !processed {
+                Either::A(
+                web3.eth().transaction(TransactionId::Hash(tx_hash))
+                .map_err(move |err| error!("Could not fetch transaction data from transaction hash: {:?}. Got error: {:?}", tx_hash, err))
+                .and_then(move |maybe_tx| {
+                    // Unlikely to error out since we only call this on
+                    // transaction hashes which were inside a mined block that
+                    // had many confirmations
+                    if let Some(tx) = maybe_tx { ok(tx) } else { err(())}
+                })
+                .and_then(move |tx| {
+                    trace!("Inspecting transaction: {:?}", tx);
+                    let (from, amount, token_address) = sent_to_us(tx, our_address);
+                    if amount > U256::from(0) {
+                        // if the tx was for us and had some non-0 amount, then let
+                        // the connector know
+                        let addr = Addresses {
+                            own_address: from,
+                            token_address,
+                        };
+                        Either::A(
+                        store.load_account_id_from_address(addr)
+                        .and_then(move |id| {
+                            self_clone.notify_connector(id.to_string(), amount.low_u64(), tx_hash)
+                        })
+                        .and_then(move |_| {
+                            // only save the transaction hash if the connector
+                            // was successfully notified
+                            store.mark_tx_processed(tx_hash)
+                        }))
+                    } else {
+                        // otherwise return an empty future
+                        Either::B(ok(()))
+                    }
+                }))
+            } else {
+                Either::B(ok(())) // return an empty future otherwise since we want to skip this transaction
+            }
+        })
+    }
+
+    fn notify_connector(
+        &self,
+        account_id: String,
+        amount: u64,
+        tx_hash: H256,
+    ) -> impl Future<Item = (), Error = ()> {
+        let mut url = self.connector_url.clone();
+        let account_id_clone = account_id.clone();
+        url.path_segments_mut()
+            .expect("Invalid connector URL")
+            .push("accounts")
+            .push(&account_id.clone())
+            .push("settlement");
+        let client = Client::new();
+        debug!("Making POST to {:?} {:?} about {:?}", url, amount, tx_hash);
+        let action = move || {
+            let account_id = account_id.clone();
+            client
+                .post(url.clone())
+                .header("Idempotency-Key", tx_hash.to_string())
+                .json(&json!({ "amount": amount }))
+                .send()
+                .map_err(move |err| {
+                    error!(
+                        "Error notifying Accounting System's account: {:?}, amount: {:?}: {:?}",
+                        account_id, amount, err
+                    )
+                })
+                .and_then(move |response| {
+                    trace!("Accounting system responded with {:?}", response);
+                    if response.status().is_success() {
+                        Ok(())
+                    } else {
+                        Err(())
+                    }
+                })
+        };
+        Retry::spawn(
+            ExponentialBackoff::from_millis(10).take(MAX_RETRIES),
+            action,
+        )
+        .map_err(move |_| {
+            error!("Exceeded max retries when notifying connector about account {:?} for amount {:?} and transaction hash {:?}. Please check your API.", account_id_clone, amount, tx_hash)
+        })
+    }
+
+    /// Helper function which submits an Ethereum ledger transaction to `to` for `amount`.
+    /// If called with `token_address`, it makes an ERC20 transaction instead.
+    /// Due to the lack of an API to create and sign the transaction
+    /// automatically it has to be done manually as follows:
+    /// 1. fetch the account's nonce
+    /// 2. construct the raw transaction using the nonce and the provided parameters
+    /// 3. Sign the transaction (along with the chain id, due to EIP-155)
+    /// 4. Submit the RLP-encoded transaction to the network
+    fn settle_to(
+        &self,
+        to: Address,
+        amount: U256,
+        token_address: Option<Address>,
+    ) -> Box<dyn Future<Item = H256, Error = ()> + Send> {
+        let web3 = self.web3.clone();
+        let own_address = self.address.own_address;
+        let chain_id = self.chain_id;
+        let signer = self.signer.clone();
+
+        let mut tx = make_tx(to, amount, token_address);
+        let gas_amount_fut = web3.eth().estimate_gas(
+            CallRequest {
+                to,
+                from: None,
+                gas: None,
+                gas_price: None,
+                value: Some(tx.value),
+                data: Some(tx.data.clone().into()),
+            },
+            None,
+        );
+        let gas_price_fut = web3.eth().gas_price();
+        let nonce_fut = web3
+            .eth()
+            .transaction_count(own_address, Some(BlockNumber::Pending));
+        Box::new(
+            join_all(vec![gas_price_fut, gas_amount_fut, nonce_fut])
+                .map_err(|err| error!("Error when querying gas price / nonce: {:?}", err))
+                .and_then(move |data| {
+                    tx.gas_price = data[0];
+                    tx.gas = data[1];
+                    tx.nonce = data[2];
+
+                    let signed_tx = signer.sign_raw_tx(tx.clone(), chain_id); // 3
+                    debug!("Sending transaction: {:?}", signed_tx);
+                    let action = move || {
+                        web3.eth() // 4
+                            .send_raw_transaction(signed_tx.clone().into())
+                    };
+                    Retry::spawn(
+                        ExponentialBackoff::from_millis(10).take(MAX_RETRIES),
+                        action,
+                    )
+                    .map_err(move |err| {
+                        error!("Error when sending transaction {:?}: {:?}", tx, err)
+                    })
+                }),
+        )
+    }
+
+    /// Helper function that returns the addresses associated with an
+    /// account from a given string account id
+    fn load_account(
+        &self,
+        account_id: String,
+    ) -> impl Future<Item = (A::AccountId, Addresses), Error = String> {
+        let store = self.store.clone();
+        let addr = self.address;
+        result(A::AccountId::from_str(&account_id).map_err(move |_err| {
+            let error_msg = "Unable to parse account".to_string();
+            error!("{}", error_msg);
+            error_msg
+        }))
+        .and_then(move |account_id| {
+            store
+                .load_account_addresses(vec![account_id])
+                .map_err(move |_err| {
+                    let error_msg = format!("[{:?}] Error getting account: {}", addr, account_id);
+                    error!("{}", error_msg);
+                    error_msg
+                })
+                .and_then(move |addresses| ok((account_id, addresses[0])))
+        })
+    }
+}
+
+impl<S, Si, A> SettlementEngine for EthereumLedgerSettlementEngine<S, Si, A>
+where
+    S: EthereumStore<Account = A> + Clone + Send + Sync + 'static,
+    Si: EthereumLedgerTxSigner + Clone + Send + Sync + 'static,
+    A: EthereumAccount + Send + Sync + 'static,
+{
+    /// Settlement Engine's function that corresponds to the
+    /// /accounts/:id/ endpoint (POST). It queries the connector's
+    /// accounts/:id/messages with a "PaymentDetailsRequest" that gets forwarded
+    /// to the connector's peer that matches the provided account id, which
+    /// finally gets forwarded to the peer SE's receive_message endpoint which
+    /// responds with its Ethereum and Token addresses. Upon
+    /// receival of Ethereum and Token addresses from the peer, it saves them in
+    /// the store.
+    fn create_account(
+        &self,
+        account_id: String,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+        let self_clone = self.clone();
+        let store: S = self.store.clone();
+
+        Box::new(
+            result(A::AccountId::from_str(&account_id).map_err({
+                move |_err| {
+                    let error_msg = "Unable to parse account".to_string();
+                    error!("{}", error_msg);
+                    let status_code = StatusCode::from_u16(400).unwrap();
+                    (status_code, error_msg)
+                }
+            }))
+            .and_then(move |account_id| {
+                // We make a POST request to OUR connector's `messages`
+                // endpoint. This will in turn send an outgoing
+                // request to its peer connector, which will ask its
+                // own engine about its settlement information. Then,
+                // we store that information and use it when
+                // performing settlements.
+                let idempotency_uuid = Uuid::new_v4().to_hyphenated().to_string();
+                let challenge = Uuid::new_v4().to_hyphenated().to_string();
+                let challenge = challenge.into_bytes();
+                let challenge_clone = challenge.clone();
+                let client = Client::new();
+                let mut url = self_clone.connector_url.clone();
+                url.path_segments_mut()
+                    .expect("Invalid connector URL")
+                    .push("accounts")
+                    .push(&account_id.to_string())
+                    .push("messages");
+                let action = move || {
+                    client
+                        .post(url.clone())
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Idempotency-Key", idempotency_uuid.clone())
+                        .body(challenge.clone())
+                        .send()
+                };
+
+                Retry::spawn(
+                    ExponentialBackoff::from_millis(10).take(MAX_RETRIES),
+                    action,
+                )
+                .map_err(move |err| {
+                    let err = format!("Couldn't notify connector {:?}", err);
+                    error!("{}", err);
+                    (StatusCode::from_u16(500).unwrap(), err)
+                })
+                .and_then(move |resp| {
+                    parse_body_into_payment_details(resp).and_then(move |payment_details| {
+                        let data = prefixed_mesage(challenge_clone);
+                        let challenge_hash = Sha3::digest(&data);
+                        let recovered_address = payment_details.sig.recover(&challenge_hash);
+                        debug!("Received payment details {:?}", payment_details);
+                        result(recovered_address)
+                            .map_err(move |err| {
+                                let err = format!("Could not recover address {:?}", err);
+                                error!("{}", err);
+                                (StatusCode::from_u16(502).unwrap(), err)
+                            })
+                            .and_then({
+                                let payment_details = payment_details.clone();
+                                move |recovered_address| {
+                                    if recovered_address.as_bytes()
+                                        == &payment_details.to.own_address.to_vec()[..]
+                                    {
+                                        ok(())
+                                    } else {
+                                        let error_msg = format!(
+                                            "Recovered address did not match: {:?}. Expected {:?}",
+                                            recovered_address, payment_details.to
+                                        );
+                                        error!("{}", error_msg);
+                                        err((StatusCode::from_u16(502).unwrap(), error_msg))
+                                    }
+                                }
+                            })
+                            .and_then(move |_| {
+                                let data =
+                                    HashMap::from_iter(vec![(account_id, payment_details.to)]);
+                                store.save_account_addresses(data).map_err(move |err| {
+                                    let err = format!("Couldn't connect to store {:?}", err);
+                                    error!("{}", err);
+                                    (StatusCode::from_u16(500).unwrap(), err)
+                                })
+                            })
+                    })
+                })
+                .and_then(move |_| Ok((StatusCode::from_u16(201).unwrap(), "CREATED".to_owned())))
+            }),
+        )
+    }
+
+    /// Settlement Engine's function that corresponds to the
+    /// /accounts/:id/messages endpoint (POST).
+    /// The body is a challenge issued by the peer's settlement engine which we
+    /// must sign to prove ownership of our address
+    fn receive_message(
+        &self,
+        account_id: String,
+        body: Vec<u8>,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+        let address = self.address;
+        // We are only returning our information, so
+        // there is no need to return any data about the
+        // provided account.
+        debug!(
+            "Responding with our account's details {} {:?}",
+            account_id, address
+        );
+        let data = prefixed_mesage(body.clone());
+        let signature = self.signer.sign_message(&data);
+        let resp = {
+            let ret = PaymentDetailsResponse::new(address, signature);
+            serde_json::to_string(&ret).unwrap()
+        };
+        Box::new(ok((StatusCode::from_u16(200).unwrap(), resp)))
+    }
+    /// Settlement Engine's function that corresponds to the
+    /// /accounts/:id/settlement endpoint (POST). It performs an Ethereum
+    /// onchain transaction to the Ethereum Address that corresponds to the
+    /// provided account id, for the amount specified in the message's body. If
+    /// the account is associated with an ERC20 token, it makes an ERC20 call instead.
+    fn send_money(
+        &self,
+        account_id: String,
+        body: Quantity,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send> {
+        let amount = U256::from(body.amount);
+        let self_clone = self.clone();
+
+        Box::new(
+            self_clone
+                .load_account(account_id)
+                .map_err(move |err| {
+                    let error_msg = format!("Error loading account {:?}", err);
+                    error!("{}", error_msg);
+                    (StatusCode::from_u16(400).unwrap(), error_msg)
+                })
+                .and_then(move |(_account_id, addresses)| {
+                    self_clone
+                        .settle_to(addresses.own_address, amount, addresses.token_address)
+                        .map_err(move |_| {
+                            let error_msg = "Error connecting to the blockchain.".to_string();
+                            error!("{}", error_msg);
+                            (StatusCode::from_u16(502).unwrap(), error_msg)
+                        })
+                })
+                .and_then(move |_| Ok((StatusCode::OK, "OK".to_string()))),
+        )
+    }
+}
+
+fn parse_body_into_payment_details(
+    resp: HttpResponse,
+) -> impl Future<Item = PaymentDetailsResponse, Error = ApiResponse> {
+    resp.into_body()
+        .concat2()
+        .map_err(|err| {
+            let err = format!("Couldn't retrieve body {:?}", err);
+            error!("{}", err);
+            (StatusCode::from_u16(500).unwrap(), err)
+        })
+        .and_then(move |body| {
+            serde_json::from_slice::<PaymentDetailsResponse>(&body).map_err(|err| {
+                let err = format!(
+                    "Couldn't parse body {:?} into payment details {:?}",
+                    body, err
+                );
+                error!("{}", err);
+                (StatusCode::from_u16(500).unwrap(), err)
+            })
+        })
+}
+
+fn prefixed_mesage(challenge: Vec<u8>) -> Vec<u8> {
+    let mut ret = ETH_CREATE_ACCOUNT_PREFIX.to_vec();
+    ret.extend(challenge);
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::fixtures::{ALICE, BOB, MESSAGES_API};
+    use super::super::test_helpers::{
+        block_on, start_ganache, test_engine, test_store, TestAccount,
+    };
+    use super::*;
+    use lazy_static::lazy_static;
+    use mockito;
+
+    lazy_static! {
+        pub static ref ALICE_PK: String =
+            String::from("380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc");
+        pub static ref BOB_PK: String =
+            String::from("cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e");
+    }
+
+    #[test]
+    // All tests involving ganache must be run in 1 suite so that they run serially
+    fn test_send_money() {
+        let _ = env_logger::try_init();
+        let alice = ALICE.clone();
+        let bob = BOB.clone();
+
+        let alice_store = test_store(ALICE.clone(), false, false, true);
+        alice_store
+            .save_account_addresses(HashMap::from_iter(vec![(
+                0,
+                Addresses {
+                    own_address: bob.address,
+                    token_address: None,
+                },
+            )]))
+            .wait()
+            .unwrap();
+
+        let bob_store = test_store(bob.clone(), false, false, true);
+        bob_store
+            .save_account_addresses(HashMap::from_iter(vec![(
+                42,
+                Addresses {
+                    own_address: alice.address,
+                    token_address: None,
+                },
+            )]))
+            .wait()
+            .unwrap();
+
+        let mut ganache_pid = start_ganache();
+
+        let bob_mock = mockito::mock("POST", "/accounts/42/settlement")
+            .match_body(mockito::Matcher::JsonString(
+                "{\"amount\": 100 }".to_string(),
+            ))
+            .with_status(200)
+            .with_body("OK".to_string())
+            .create();
+
+        let bob_connector_url = mockito::server_url();
+        let _bob_engine = test_engine(
+            bob_store.clone(),
+            BOB_PK.clone(),
+            0,
+            &bob_connector_url,
+            true,
+        );
+
+        let alice_engine = test_engine(
+            alice_store.clone(),
+            ALICE_PK.clone(),
+            0,
+            "http://127.0.0.1:9999",
+            false, // alice sends the transaction to bob (set it up so that she doesn't listen for inc txs)
+        );
+
+        let ret = block_on(alice_engine.send_money(bob.id.to_string(), Quantity { amount: 100 }))
+            .unwrap();
+        assert_eq!(ret.0.as_u16(), 200);
+        assert_eq!(ret.1, "OK");
+
+        std::thread::sleep(Duration::from_millis(2000)); // wait a few seconds so that the receiver's engine that does the polling
+
+        ganache_pid.kill().unwrap(); // kill ganache since it's no longer needed
+        bob_mock.assert();
+    }
+
+    #[test]
+    fn test_create_get_account() {
+        let bob: TestAccount = BOB.clone();
+
+        let challenge = Uuid::new_v4().to_hyphenated().to_string();
+        let signature = BOB_PK.clone().sign_message(&challenge.clone().into_bytes());
+
+        let body_se_data = serde_json::to_string(&PaymentDetailsResponse {
+            to: Addresses {
+                own_address: bob.address,
+                token_address: None,
+            },
+            sig: signature,
+        })
+        .unwrap();
+
+        // simulate our connector that accepts the request, forwards it to the
+        // peer's connector and returns the peer's se addresses
+        let m = mockito::mock("POST", MESSAGES_API.clone())
+            .with_status(200)
+            .with_body(body_se_data)
+            .expect(1) // only 1 request is made to the connector (idempotency works properly)
+            .create();
+        let connector_url = mockito::server_url();
+
+        // alice sends a create account request to her engine
+        // which makes a call to bob's connector which replies with bob's
+        // address and signature on the challenge
+        let store = test_store(bob.clone(), false, false, false);
+        let engine = test_engine(store.clone(), ALICE_PK.clone(), 0, &connector_url, false);
+
+        // the signed message does not match. We are not able to make Mockito
+        // capture the challenge and return a signature on it.
+        let ret = block_on(engine.create_account(bob.id.to_string())).unwrap_err();
+        assert_eq!(ret.0.as_u16(), 502);
+        // assert_eq!(ret.1, "CREATED");
+
+        m.assert();
+    }
+
+    #[test]
+    fn test_receive_message() {
+        let bob: TestAccount = BOB.clone();
+
+        let challenge = Uuid::new_v4().to_hyphenated().to_string().into_bytes();
+        let signed_challenge = prefixed_mesage(challenge.clone());
+
+        let signature = ALICE_PK.clone().sign_message(&signed_challenge);
+
+        let store = test_store(ALICE.clone(), false, false, false);
+        let engine = test_engine(
+            store.clone(),
+            ALICE_PK.clone(),
+            0,
+            "http://127.0.0.1:8770",
+            false,
+        );
+
+        // Alice's engine receives a challenge by Bob.
+        let ret = block_on(engine.receive_message(bob.id.to_string(), challenge)).unwrap();
+        assert_eq!(ret.0.as_u16(), 200);
+
+        let alice_addrs = Addresses {
+            own_address: ALICE.address,
+            token_address: None,
+        };
+        let data: PaymentDetailsResponse = serde_json::from_str(&ret.1).unwrap();
+        // The returned addresses must be Alice's
+        assert_eq!(data.to, alice_addrs);
+        // The returned signature must be Alice's sig.
+        assert_eq!(data.sig, signature);
+    }
+}

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/fixtures.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/fixtures.rs
@@ -1,0 +1,19 @@
+use super::test_helpers::TestAccount;
+use lazy_static::lazy_static;
+use mockito::Matcher;
+
+lazy_static! {
+    pub static ref ALICE: TestAccount = TestAccount::new(
+        1,
+        "3cdb3d9e1b74692bb1e3bb5fc81938151ca64b02",
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    );
+    pub static ref BOB: TestAccount = TestAccount::new(
+        0,
+        "9b925641c5ef3fd86f63bff2da55a0deeafd1263",
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    );
+    pub static ref SETTLEMENT_API: Matcher =
+        Matcher::Regex(r"^/accounts/\d*/settlement$".to_string());
+    pub static ref MESSAGES_API: Matcher = Matcher::Regex(r"^/accounts/\d*/messages$".to_string());
+}

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/mod.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/mod.rs
@@ -1,0 +1,15 @@
+mod eth_engine;
+mod types;
+mod utils;
+
+#[cfg(test)]
+pub mod fixtures;
+#[cfg(test)]
+pub mod test_helpers;
+
+// Only expose the engine and the ledger signer
+pub use eth_engine::{EthereumLedgerSettlementEngine, EthereumLedgerSettlementEngineBuilder};
+pub use ethereum_tx_sign::web3::types::Address as EthAddress;
+pub use types::{
+    Addresses as EthereumAddresses, EthereumAccount, EthereumLedgerTxSigner, EthereumStore,
+};

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/test_helpers.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/test_helpers.rs
@@ -1,0 +1,309 @@
+use bytes::Bytes;
+use interledger_service::{Account, AccountStore};
+use tokio::runtime::Runtime;
+
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use hyper::StatusCode;
+use std::process::Command;
+use std::str::FromStr;
+use std::thread::sleep;
+use std::time::Duration;
+
+use ethereum_tx_sign::web3::{
+    futures::future::{err, ok, Future},
+    types::{Address, H256, U256},
+};
+
+use super::eth_engine::{EthereumLedgerSettlementEngine, EthereumLedgerSettlementEngineBuilder};
+use super::types::{Addresses, EthereumAccount, EthereumLedgerTxSigner, EthereumStore};
+use interledger_settlement::{IdempotentData, IdempotentStore};
+
+#[derive(Debug, Clone)]
+pub struct TestAccount {
+    pub id: u64,
+    pub address: Address,
+    pub token_address: Address,
+    pub no_details: bool,
+}
+
+impl Account for TestAccount {
+    type AccountId = u64;
+
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
+impl EthereumAccount for TestAccount {
+    fn token_address(&self) -> Option<Address> {
+        if self.no_details {
+            return None;
+        }
+        Some(self.token_address)
+    }
+    fn own_address(&self) -> Address {
+        self.address
+    }
+}
+
+// Test Store
+#[derive(Clone)]
+pub struct TestStore {
+    pub accounts: Arc<Vec<TestAccount>>,
+    pub should_fail: bool,
+    pub addresses: Arc<RwLock<HashMap<u64, Addresses>>>,
+    pub address_to_id: Arc<RwLock<HashMap<Addresses, u64>>>,
+    #[allow(clippy::all)]
+    pub cache: Arc<RwLock<HashMap<String, (StatusCode, String, [u8; 32])>>>,
+    pub last_observed_block: Arc<RwLock<U256>>,
+    pub saved_hashes: Arc<RwLock<HashMap<H256, bool>>>,
+    pub cache_hits: Arc<RwLock<u64>>,
+}
+
+impl EthereumStore for TestStore {
+    type Account = TestAccount;
+
+    fn save_account_addresses(
+        &self,
+        data: HashMap<u64, Addresses>,
+    ) -> Box<Future<Item = (), Error = ()> + Send> {
+        let mut guard = self.addresses.write();
+        let mut guard2 = self.address_to_id.write();
+        for (acc, d) in data {
+            (*guard).insert(acc, d);
+            (*guard2).insert(d, acc);
+        }
+        Box::new(ok(()))
+    }
+
+    fn load_account_addresses(
+        &self,
+        account_ids: Vec<u64>,
+    ) -> Box<dyn Future<Item = Vec<Addresses>, Error = ()> + Send> {
+        let mut v = Vec::with_capacity(account_ids.len());
+        let addresses = self.addresses.read();
+        for acc in &account_ids {
+            if let Some(d) = addresses.get(&acc) {
+                v.push(Addresses {
+                    own_address: d.own_address,
+                    token_address: d.token_address,
+                });
+            } else {
+                // if the account is not found, error out
+                return Box::new(err(()));
+            }
+        }
+        Box::new(ok(v))
+    }
+
+    fn save_recently_observed_block(
+        &self,
+        block: U256,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        let mut guard = self.last_observed_block.write();
+        *guard = block;
+        Box::new(ok(()))
+    }
+
+    fn load_recently_observed_block(&self) -> Box<dyn Future<Item = U256, Error = ()> + Send> {
+        Box::new(ok(*self.last_observed_block.read()))
+    }
+
+    fn load_account_id_from_address(
+        &self,
+        eth_address: Addresses,
+    ) -> Box<dyn Future<Item = u64, Error = ()> + Send> {
+        let addresses = self.address_to_id.read();
+        let d = if let Some(d) = addresses.get(&eth_address) {
+            *d
+        } else {
+            return Box::new(err(()));
+        };
+
+        Box::new(ok(d))
+    }
+
+    fn check_if_tx_processed(
+        &self,
+        tx_hash: H256,
+    ) -> Box<dyn Future<Item = bool, Error = ()> + Send> {
+        let hashes = self.saved_hashes.read();
+        // if hash exists then return error
+        if hashes.get(&tx_hash).is_some() {
+            Box::new(ok(true))
+        } else {
+            Box::new(ok(false))
+        }
+    }
+
+    fn mark_tx_processed(&self, tx_hash: H256) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        let mut hashes = self.saved_hashes.write();
+        (*hashes).insert(tx_hash, true);
+        Box::new(ok(()))
+    }
+}
+
+impl AccountStore for TestStore {
+    type Account = TestAccount;
+
+    fn get_accounts(
+        &self,
+        account_ids: Vec<<<Self as AccountStore>::Account as Account>::AccountId>,
+    ) -> Box<Future<Item = Vec<Self::Account>, Error = ()> + Send> {
+        let accounts: Vec<TestAccount> = self
+            .accounts
+            .iter()
+            .filter_map(|account| {
+                if account_ids.contains(&account.id) {
+                    Some(account.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if accounts.len() == account_ids.len() {
+            Box::new(ok(accounts))
+        } else {
+            Box::new(err(()))
+        }
+    }
+}
+
+impl IdempotentStore for TestStore {
+    fn load_idempotent_data(
+        &self,
+        idempotency_key: String,
+    ) -> Box<dyn Future<Item = IdempotentData, Error = ()> + Send> {
+        let cache = self.cache.read();
+        if let Some(data) = cache.get(&idempotency_key) {
+            let mut guard = self.cache_hits.write();
+            *guard += 1; // used to test how many times this branch gets executed
+            Box::new(ok((data.0, Bytes::from(data.1.clone()), data.2)))
+        } else {
+            Box::new(err(()))
+        }
+    }
+
+    fn save_idempotent_data(
+        &self,
+        idempotency_key: String,
+        input_hash: [u8; 32],
+        status_code: StatusCode,
+        data: Bytes,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        let mut cache = self.cache.write();
+        cache.insert(
+            idempotency_key,
+            (
+                status_code,
+                String::from_utf8_lossy(&data).to_string(),
+                input_hash,
+            ),
+        );
+        Box::new(ok(()))
+    }
+}
+
+impl TestStore {
+    pub fn new(accs: Vec<TestAccount>, should_fail: bool, initialize: bool) -> Self {
+        let mut addresses = HashMap::new();
+        let mut address_to_id = HashMap::new();
+        if initialize {
+            for account in &accs {
+                let token_address = if !account.no_details {
+                    Some(account.token_address)
+                } else {
+                    None
+                };
+                let addrs = Addresses {
+                    own_address: account.address,
+                    token_address,
+                };
+                addresses.insert(account.id, addrs);
+                address_to_id.insert(addrs, account.id);
+            }
+        }
+
+        TestStore {
+            accounts: Arc::new(accs),
+            should_fail,
+            addresses: Arc::new(RwLock::new(addresses)),
+            address_to_id: Arc::new(RwLock::new(address_to_id)),
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            cache_hits: Arc::new(RwLock::new(0)),
+            last_observed_block: Arc::new(RwLock::new(U256::from(0))),
+            saved_hashes: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+// Test Service
+
+impl TestAccount {
+    pub fn new(id: u64, address: &str, token_address: &str) -> Self {
+        Self {
+            id,
+            address: Address::from_str(address).unwrap(),
+            token_address: Address::from_str(token_address).unwrap(),
+            no_details: false,
+        }
+    }
+}
+
+// Helper to create a new engine and spin a new ganache instance.
+pub fn test_engine<Si, S, A>(
+    store: S,
+    key: Si,
+    confs: u8,
+    connector_url: &str,
+    watch_incoming: bool,
+) -> EthereumLedgerSettlementEngine<S, Si, A>
+where
+    Si: EthereumLedgerTxSigner + Clone + Send + Sync + 'static,
+    S: EthereumStore<Account = A> + IdempotentStore + Clone + Send + Sync + 'static,
+    A: EthereumAccount + Send + Sync + 'static,
+{
+    EthereumLedgerSettlementEngineBuilder::new(store, key)
+        .connector_url(connector_url)
+        .confirmations(confs)
+        .watch_incoming(watch_incoming)
+        .poll_frequency(1000)
+        .connect()
+}
+
+pub fn start_ganache() -> std::process::Child {
+    let mut ganache = Command::new("ganache-cli");
+    let ganache = ganache.stdout(std::process::Stdio::null()).arg("-m").arg(
+        "abstract vacuum mammal awkward pudding scene penalty purchase dinner depart evoke puzzle",
+    );
+    let ganache_pid = ganache.spawn().expect("couldnt start ganache-cli");
+    // wait a couple of seconds for ganache to boot up
+    sleep(Duration::from_secs(5));
+    ganache_pid
+}
+
+pub fn test_store(
+    account: TestAccount,
+    store_fails: bool,
+    account_has_engine: bool,
+    initialize: bool,
+) -> TestStore {
+    let mut acc = account.clone();
+    acc.no_details = !account_has_engine;
+    TestStore::new(vec![acc], store_fails, initialize)
+}
+
+// Futures helper taken from the store_helpers in interledger-store-redis.
+pub fn block_on<F>(f: F) -> Result<F::Item, F::Error>
+where
+    F: Future + Send + 'static,
+    F::Item: Send,
+    F::Error: Send,
+{
+    let _ = env_logger::try_init();
+    let mut runtime = Runtime::new().unwrap();
+    runtime.block_on(f)
+}

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/types.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/types.rs
@@ -1,0 +1,128 @@
+use clarity::{PrivateKey, Signature};
+use ethereum_tx_sign::{
+    web3::types::{Address, H256, U256},
+    RawTransaction,
+};
+use futures::Future;
+use interledger_service::Account;
+use sha3::{Digest, Keccak256 as Sha3};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// An Ethereum account is associated with an address. We additionally require
+/// that an optional `token_address` is implemented. If the `token_address` of an
+/// Ethereum Account is not `None`, than that account is used with the ERC20 token
+/// associated with that `token_address`.
+pub trait EthereumAccount: Account {
+    fn own_address(&self) -> Address;
+
+    fn token_address(&self) -> Option<Address> {
+        None
+    }
+}
+
+#[derive(Debug, Extract, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct Addresses {
+    pub own_address: Address,
+    pub token_address: Option<Address>,
+}
+
+/// Trait used to store Ethereum account addresses, as well as any data related
+/// to the connector notifier service such as the most recently observed block
+/// and account balance
+pub trait EthereumStore {
+    type Account: EthereumAccount;
+
+    /// Saves the Ethereum address associated with this account
+    /// called when creating an account on the API.
+    fn save_account_addresses(
+        &self,
+        data: HashMap<<Self::Account as Account>::AccountId, Addresses>,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+
+    /// Loads the Ethereum address associated with this account
+    fn load_account_addresses(
+        &self,
+        account_ids: Vec<<Self::Account as Account>::AccountId>,
+    ) -> Box<dyn Future<Item = Vec<Addresses>, Error = ()> + Send>;
+
+    /// Saves the latest block number, up to which all
+    /// transactions have been communicated to the connector
+    fn save_recently_observed_block(
+        &self,
+        block: U256,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+
+    /// Loads the latest saved block number
+    fn load_recently_observed_block(&self) -> Box<dyn Future<Item = U256, Error = ()> + Send>;
+
+    /// Retrieves the account id associated with the provided addresses pair.
+    /// Note that an account with the same `own_address` but different ERC20
+    /// `token_address` can exist multiple times since each occurence represents
+    /// a different token.
+    fn load_account_id_from_address(
+        &self,
+        eth_address: Addresses,
+    ) -> Box<dyn Future<Item = <Self::Account as Account>::AccountId, Error = ()> + Send>;
+
+    /// Returns true if the transaction has already been processed and saved in
+    /// the store.
+    fn check_if_tx_processed(
+        &self,
+        tx_hash: H256,
+    ) -> Box<dyn Future<Item = bool, Error = ()> + Send>;
+
+    /// Saves the transaction hash in the store.
+    fn mark_tx_processed(&self, tx_hash: H256) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+}
+
+/// Implement this trait for datatypes which can be used to sign an Ethereum
+/// Transaction, e.g. an HSM, Ledger, Trezor connection, or a private key
+/// string.
+/// TODO: All methods should be converted to return a Future, since an HSM
+/// connection is asynchronous
+pub trait EthereumLedgerTxSigner {
+    /// Takes a transaction and returns an RLP encoded signed version of it
+    fn sign_raw_tx(&self, tx: RawTransaction, chain_id: u8) -> Vec<u8>;
+
+    /// Takes a message and returns a signature on it
+    fn sign_message(&self, message: &[u8]) -> Signature;
+
+    /// Returns the Ethereum address associated with the signer
+    fn address(&self) -> Address;
+}
+
+impl EthereumLedgerTxSigner for String {
+    fn sign_raw_tx(&self, tx: RawTransaction, chain_id: u8) -> Vec<u8> {
+        tx.sign(&H256::from_str(self).unwrap(), &chain_id)
+    }
+
+    fn sign_message(&self, message: &[u8]) -> Signature {
+        let private_key: PrivateKey = self.parse().unwrap();
+        let hash = Sha3::digest(message);
+        private_key.sign_hash(&hash)
+    }
+
+    fn address(&self) -> Address {
+        let private_key: PrivateKey = self.parse().unwrap();
+        let address = private_key.to_public_key().unwrap();
+        // Address type from clarity library must convert to web3 Address
+        Address::from(address.as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_address() {
+        let privkey =
+            String::from("acb8f4184aaf6490b6e6aea7b474225be0d965eed75f4b91183eff6032c299f8");
+        let addr = privkey.address();
+        assert_eq!(
+            addr,
+            Address::from("4070abbd2e38a8d27cd5a495f482c13f049f8310")
+        );
+    }
+}

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/utils.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/utils.rs
@@ -1,0 +1,174 @@
+use ethabi::Token;
+use ethereum_tx_sign::{
+    web3::{
+        api::Web3,
+        futures::future::Future,
+        transports::Http,
+        types::{Address, BlockNumber, FilterBuilder, Transaction, H160, H256, U256},
+    },
+    RawTransaction,
+};
+use log::error;
+use std::str::FromStr;
+
+/// This is the result of keccak256("Transfer(address,address,to)"), which is
+/// used to filter through Ethereum ERC20 Transfer events in transaction receipts.
+const TRANSFER_EVENT_FILTER: &str =
+    "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+// Helper function which is used to construct an Ethereum transaction sending
+// `value` tokens to `to`. If a `token_address` is provided, then an ERC20
+// transaction  is created instead for that token. The `nonce`, `gas` and
+// `gas_price` fields are set to 0 and are expected to be set with the values
+// returned by the corresponding `eth_getTransactionCount`, `eth_estimateGas`,
+// `eth_gasPrice` calls to an Ethereum node.
+pub fn make_tx(to: Address, value: U256, token_address: Option<Address>) -> RawTransaction {
+    if let Some(token_address) = token_address {
+        // Ethereum contract transactions format:
+        // [transfer function selector][`to` padded ][`value` padded]
+        // transfer function selector: sha3("transfer(to,address)")[0:8] =
+        // "a9059cbb"
+        // The actual receiver of the transaction is the ERC20 `token_address`
+        // The value of the transaction is 0 wei since we are transferring an ERC20
+        let mut data = hex::decode("a9059cbb").unwrap();
+        data.extend(ethabi::encode(&[Token::Address(to), Token::Uint(value)]));
+        RawTransaction {
+            to: Some(token_address),
+            nonce: U256::from(0),
+            data,
+            gas: U256::from(0),
+            gas_price: U256::from(0),
+            value: U256::zero(),
+        }
+    } else {
+        // Ethereum account transaction:
+        // The receiver is `to`, and the data field is left empty.
+        RawTransaction {
+            to: Some(to),
+            nonce: U256::from(0),
+            data: vec![],
+            gas: U256::from(0),
+            gas_price: U256::from(0),
+            value,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ERC20Transfer {
+    pub tx_hash: H256,
+    pub from: Address,
+    pub to: Address,
+    pub amount: U256,
+}
+
+/// Filters out transactions where the `from` and `to` fields match the provides
+/// addreses.
+pub fn filter_transfer_logs(
+    web3: Web3<Http>,
+    contract_address: Address,
+    from: Option<Address>,
+    to: Option<Address>,
+    from_block: BlockNumber,
+    to_block: BlockNumber,
+) -> impl Future<Item = Vec<ERC20Transfer>, Error = ()> {
+    let from = if let Some(from) = from {
+        Some(vec![H256::from(from)])
+    } else {
+        None
+    };
+    let to = if let Some(to) = to {
+        Some(vec![H256::from(to)])
+    } else {
+        None
+    };
+
+    // create a filter for Transfer events from `from_block` until `to_block
+    // that filters all events indexed by `from` and `to`.
+    let filter = FilterBuilder::default()
+        .from_block(from_block)
+        .to_block(to_block)
+        .address(vec![contract_address])
+        .topics(
+            Some(vec![H256::from(
+                // keccak256("transfer(address,address,to)")
+                TRANSFER_EVENT_FILTER,
+            )]),
+            from,
+            to,
+            None,
+        )
+        .build();
+
+    // Make an eth_getLogs call to the Ethereum node
+    web3.eth()
+        .logs(filter)
+        .map_err(move |err| error!("Got error when fetching transfer logs{:?}", err))
+        .and_then(move |logs| {
+            let mut ret = Vec::new();
+            for log in logs {
+                // NOTE: From/to are indexed events.
+                // Amount is parsed directly from the data field.
+                let indexed = log.topics;
+                let from = H160::from(indexed[1]);
+                let to = H160::from(indexed[2]);
+                let data = log.data;
+                let amount = U256::from_str(&hex::encode(data.0)).unwrap();
+                ret.push(ERC20Transfer {
+                    tx_hash: log.transaction_hash.unwrap(),
+                    from,
+                    to,
+                    amount,
+                });
+            }
+            Ok(ret)
+        })
+}
+
+// TODO : Extend this function to inspect the data field of a
+// transaction, so that it supports contract wallets such as the Gnosis Multisig
+// etc. Implementing this would require RLP decoding the `tx.data` field of the
+// transaction to get the arguments of the function called. If any of them
+// indicates that it's a transaction made to our account, it should return
+// the address of the contract.
+// There is no need to implement any ERC20 functionality here since these
+// transfers can be quickly found by filtering for the `Transfer` ERC20 event.
+
+pub fn sent_to_us(tx: Transaction, our_address: Address) -> (Address, U256, Option<Address>) {
+    if let Some(to) = tx.to {
+        if tx.value > U256::from(0) && to == our_address {
+            return (tx.from, tx.value, None);
+        }
+    }
+    (tx.from, U256::from(0), None) // if it's not for us the amount is 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_erc20_make_tx() {
+        // https://etherscan.io/tx/0x6fd1b68f02f4201a38662647b7f09170b159faec6af4825ae509beefeb8e8130
+        let to = "c92be489639a9c61f517bd3b955840fa19bc9b7c".parse().unwrap();
+        let value = "16345785d8a0000".into();
+        let token_address = Some("B8c77482e45F1F44dE1745F52C74426C631bDD52".into());
+        let tx = make_tx(to, value, token_address);
+        assert_eq!(tx.to, token_address);
+        assert_eq!(tx.value, U256::from(0));
+        assert_eq!(hex::encode(tx.data), "a9059cbb000000000000000000000000c92be489639a9c61f517bd3b955840fa19bc9b7c000000000000000000000000000000000000000000000000016345785d8a0000")
+    }
+
+    #[test]
+    fn test_eth_make_tx() {
+        let to = "c92be489639a9c61f517bd3b955840fa19bc9b7c".parse().unwrap();
+        let value = "16345785d8a0000".into();
+        let token_address = None;
+        let tx = make_tx(to, value, token_address);
+        assert_eq!(tx.to, Some(to));
+        assert_eq!(tx.value, value);
+        let empty: Vec<u8> = Vec::new();
+        assert_eq!(tx.data, empty);
+    }
+
+}

--- a/crates/interledger-settlement-engines/src/engines/mod.rs
+++ b/crates/interledger-settlement-engines/src/engines/mod.rs
@@ -1,0 +1,1 @@
+pub mod ethereum_ledger;

--- a/crates/interledger-settlement-engines/src/lib.rs
+++ b/crates/interledger-settlement-engines/src/lib.rs
@@ -1,0 +1,51 @@
+//! # Interledger Settlement Engines
+//!
+//! Crate containing all the components for implementing the Settlement
+//! Architecture for the Interledger Protocol. The crate is structured such that
+//! an API is created by giving it an object which implements the
+//! SettlementEngine trait. All settlement engines must be implemented under the
+//! `engines` subdirectory, with a directory name describing their
+//! functionality, e.g. ethereum_ledger, ethereum_unidirectional_channel,
+//! xrp_ledger, etc.
+#![recursion_limit = "128"]
+
+#[macro_use]
+extern crate tower_web;
+
+use futures::Future;
+
+// Export all the engines
+mod api;
+pub mod engines;
+pub mod stores;
+pub use self::api::SettlementEngineApi;
+
+#[derive(Extract, Debug, Clone, Copy)]
+pub struct Quantity {
+    amount: u64,
+}
+
+use http::StatusCode;
+
+pub type ApiResponse = (StatusCode, String);
+
+/// Trait consumed by the Settlement Engine HTTP API. Every settlement engine
+/// MUST implement this trait, so that it can be then be exposed over the API.
+pub trait SettlementEngine {
+    fn send_money(
+        &self,
+        account_id: String,
+        money: Quantity,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send>;
+
+    fn receive_message(
+        &self,
+        account_id: String,
+        message: Vec<u8>,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send>;
+
+    fn create_account(
+        &self,
+        account_id: String,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiResponse> + Send>;
+}

--- a/crates/interledger-settlement-engines/src/main.rs
+++ b/crates/interledger-settlement-engines/src/main.rs
@@ -1,0 +1,189 @@
+use clap::{value_t, App, Arg, SubCommand};
+use hex;
+use std::str::FromStr;
+use tokio;
+
+use futures::Future;
+use interledger_settlement_engines::{
+    engines::ethereum_ledger::{
+        EthAddress, EthereumLedgerSettlementEngineBuilder, EthereumLedgerTxSigner,
+    },
+    stores::redis_ethereum_ledger::EthereumLedgerRedisStoreBuilder,
+    SettlementEngineApi,
+};
+use interledger_store_redis::RedisStoreBuilder;
+use log::info;
+use redis::IntoConnectionInfo;
+use ring::{digest, hmac};
+use std::{net::SocketAddr, str, u64};
+use tokio::net::TcpListener;
+use url::Url;
+
+static REDIS_SECRET_GENERATION_STRING: &str = "ilp_redis_secret";
+pub fn generate_redis_secret(secret_seed: &[u8; 32]) -> [u8; 32] {
+    let mut redis_secret: [u8; 32] = [0; 32];
+    let sig = hmac::sign(
+        &hmac::SigningKey::new(&digest::SHA256, secret_seed),
+        REDIS_SECRET_GENERATION_STRING.as_bytes(),
+    );
+    redis_secret.copy_from_slice(sig.as_ref());
+    redis_secret
+}
+
+#[allow(clippy::cognitive_complexity)]
+pub fn main() {
+    env_logger::init();
+
+    let mut app = App::new("interledger-settlement-engines")
+        .about("Interledger Settlement Engines CLI")
+        .subcommands(vec![
+            SubCommand::with_name("ethereum-ledger")
+                .about("Ethereum settlement engine which performs ledger (layer 1) transactions")
+                    .args(&[
+                        Arg::with_name("port")
+                            .long("port")
+                            .help("Port to listen for settlement requests on")
+                            .default_value("3000"),
+                        Arg::with_name("key")
+                            .long("key")
+                            .help("private key for settlement account")
+                            .takes_value(true)
+                            .required(true),
+                        Arg::with_name("ethereum_endpoint")
+                            .long("ethereum_endpoint")
+                            .help("Ethereum node endpoint")
+                            .default_value("http://127.0.0.1:8545"),
+                        Arg::with_name("token_address")
+                            .long("token_address")
+                            .help("The address of the ERC20 token to be used for settlement (defaults to sending ETH if no token address is provided)")
+                            .default_value(""),
+                        Arg::with_name("connector_url")
+                            .long("connector_url")
+                            .help("Connector Settlement API endpoint")
+                            .default_value("http://127.0.0.1:7771"),
+                        Arg::with_name("redis_uri")
+                            .long("redis_uri")
+                            .help("Redis database to add the account to")
+                            .default_value("redis://127.0.0.1:6379"),
+                        Arg::with_name("server_secret")
+                            .long("server_secret")
+                            .help("Cryptographic seed used to derive keys")
+                            .takes_value(true)
+                            .required(true),
+                        Arg::with_name("chain_id")
+                            .long("chain_id")
+                            .help("The chain id so that the signer calculates the v value of the sig appropriately")
+                            .default_value("1"),
+                        Arg::with_name("confirmations")
+                            .long("confirmations")
+                            .help("The number of confirmations the engine will wait for a transaction's inclusion before it notifies the node of its success")
+                            .default_value("6"),
+                        Arg::with_name("poll_frequency")
+                            .long("poll_frequency")
+                            .help("The frequency in milliseconds at which the engine will check the blockchain about the confirmation status of a tx")
+                            .default_value("5000"),
+                        Arg::with_name("watch_incoming")
+                            .long("watch_incoming")
+                            .help("Launch a blockchain watcher that listens for incoming transactions and notifies the connector upon sufficient confirmations")
+                            .default_value("true"),
+                    ])
+        ]
+    );
+
+    match app.clone().get_matches().subcommand() {
+        ("ethereum-ledger", Some(matches)) => {
+            let settlement_port =
+                value_t!(matches, "port", u16).expect("port for settlement engine required");
+            // TODO make compatible with
+            // https://github.com/tendermint/signatory to have HSM sigs
+            let private_key: String = value_t!(matches, "key", String).unwrap();
+            let ethereum_endpoint: String = value_t!(matches, "ethereum_endpoint", String).unwrap();
+            let token_address = value_t!(matches, "token_address", String).unwrap();
+            let token_address = if token_address.len() == 20 {
+                Some(EthAddress::from_str(&token_address).unwrap())
+            } else {
+                None
+            };
+            let connector_url: String = value_t!(matches, "connector_url", String).unwrap();
+            let redis_uri = value_t!(matches, "redis_uri", String).expect("redis_uri is required");
+            let redis_uri = Url::parse(&redis_uri).expect("redis_uri is not a valid URI");
+            let server_secret: [u8; 32] = {
+                let encoded: String = value_t!(matches, "server_secret", String).unwrap();
+                let mut server_secret = [0; 32];
+                let decoded = hex::decode(encoded).expect("server_secret must be hex-encoded");
+                assert_eq!(decoded.len(), 32, "server_secret must be 32 bytes");
+                server_secret.clone_from_slice(&decoded);
+                server_secret
+            };
+            let chain_id = value_t!(matches, "chain_id", u8).unwrap();
+            let confirmations = value_t!(matches, "confirmations", u8).unwrap();
+            let poll_frequency = value_t!(matches, "poll_frequency", u64).unwrap();
+            let watch_incoming = value_t!(matches, "watch_incoming", bool).unwrap();
+
+            tokio::run(run_settlement_engine(
+                redis_uri,
+                ethereum_endpoint,
+                settlement_port,
+                &server_secret,
+                private_key,
+                chain_id,
+                confirmations,
+                poll_frequency,
+                connector_url,
+                token_address,
+                watch_incoming,
+            ));
+        }
+        _ => app.print_help().unwrap(),
+    }
+}
+
+#[doc(hidden)]
+#[allow(clippy::all)]
+pub fn run_settlement_engine<R, Si>(
+    redis_uri: R,
+    ethereum_endpoint: String,
+    settlement_port: u16,
+    secret_seed: &[u8; 32],
+    private_key: Si,
+    chain_id: u8,
+    confirmations: u8,
+    poll_frequency: u64,
+    connector_url: String,
+    token_address: Option<EthAddress>,
+    watch_incoming: bool,
+) -> impl Future<Item = (), Error = ()>
+where
+    R: IntoConnectionInfo,
+    Si: EthereumLedgerTxSigner + Clone + Send + Sync + 'static,
+{
+    let redis_secret = generate_redis_secret(secret_seed);
+    let redis_uri = redis_uri.into_connection_info().unwrap();
+
+    EthereumLedgerRedisStoreBuilder::new(redis_uri.clone())
+        .connect()
+        .and_then(move |ethereum_store| {
+            let engine = EthereumLedgerSettlementEngineBuilder::new(ethereum_store, private_key)
+                .ethereum_endpoint(&ethereum_endpoint)
+                .chain_id(chain_id)
+                .connector_url(&connector_url)
+                .confirmations(confirmations)
+                .poll_frequency(poll_frequency)
+                .watch_incoming(watch_incoming)
+                .token_address(token_address)
+                .connect();
+
+            RedisStoreBuilder::new(redis_uri, redis_secret)
+                .connect()
+                .and_then(move |store| {
+                    let addr = SocketAddr::from(([127, 0, 0, 1], settlement_port));
+                    let listener = TcpListener::bind(&addr)
+                        .expect("Unable to bind to Settlement Engine address");
+                    info!("Ethereum Settlement Engine listening on: {}", addr);
+
+                    let api = SettlementEngineApi::new(engine, store);
+                    tokio::spawn(api.serve(listener.incoming()));
+                    Ok(())
+                })
+        })
+}

--- a/crates/interledger-settlement-engines/src/stores/mod.rs
+++ b/crates/interledger-settlement-engines/src/stores/mod.rs
@@ -1,0 +1,31 @@
+use bytes::Bytes;
+use futures::future::Future;
+use http::StatusCode;
+
+pub mod redis_ethereum_ledger;
+pub mod redis_store_common;
+
+#[cfg(test)]
+pub mod test_helpers;
+
+pub type IdempotentEngineData = (StatusCode, Bytes, [u8; 32]);
+
+pub trait IdempotentEngineStore {
+    /// Returns the API response that was saved when the idempotency key was used
+    /// Also returns a hash of the input data which resulted in the response
+    /// Returns error if the data was not found
+    fn load_idempotent_data(
+        &self,
+        idempotency_key: String,
+    ) -> Box<dyn Future<Item = IdempotentEngineData, Error = ()> + Send>;
+
+    /// Saves the data that was passed along with the api request for later
+    /// The store MUST also save a hash of the input, so that it errors out on requests
+    fn save_idempotent_data(
+        &self,
+        idempotency_key: String,
+        input_hash: [u8; 32],
+        status_code: StatusCode,
+        data: Bytes,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+}

--- a/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/mod.rs
+++ b/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/mod.rs
@@ -1,0 +1,2 @@
+mod store;
+pub use store::{EthereumLedgerRedisStore, EthereumLedgerRedisStoreBuilder};

--- a/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/store.rs
+++ b/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/store.rs
@@ -1,0 +1,385 @@
+use futures::{
+    future::{err, ok},
+    Future,
+};
+
+use ethereum_tx_sign::web3::types::{Address as EthAddress, H256, U256};
+use interledger_service::Account as AccountTrait;
+use std::collections::HashMap;
+
+use crate::engines::ethereum_ledger::{EthereumAccount, EthereumAddresses, EthereumStore};
+use redis::{self, cmd, r#async::SharedConnection, ConnectionInfo, PipelineCommands, Value};
+
+use log::{debug, error};
+
+use crate::stores::redis_store_common::{EngineRedisStore, EngineRedisStoreBuilder};
+
+// Key for the latest observed block and balance. The data is stored in order to
+// avoid double crediting transactions which have already been processed, and in
+// order to resume watching from the last observed point.
+static RECENTLY_OBSERVED_BLOCK_KEY: &str = "recently_observed_block";
+static SAVED_TRANSACTIONS_KEY: &str = "transactions";
+static SETTLEMENT_ENGINES_KEY: &str = "settlement";
+static LEDGER_KEY: &str = "ledger";
+static ETHEREUM_KEY: &str = "eth";
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Account {
+    pub(crate) id: u64,
+    pub(crate) own_address: EthAddress,
+    pub(crate) token_address: Option<EthAddress>,
+}
+
+impl AccountTrait for Account {
+    type AccountId = u64;
+
+    fn id(&self) -> Self::AccountId {
+        self.id
+    }
+}
+
+fn ethereum_transactions_key(tx_hash: H256) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        ETHEREUM_KEY, LEDGER_KEY, SAVED_TRANSACTIONS_KEY, tx_hash,
+    )
+}
+
+fn ethereum_ledger_key(account_id: u64) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        ETHEREUM_KEY, LEDGER_KEY, SETTLEMENT_ENGINES_KEY, account_id
+    )
+}
+
+impl EthereumAccount for Account {
+    fn token_address(&self) -> Option<EthAddress> {
+        self.token_address
+    }
+
+    fn own_address(&self) -> EthAddress {
+        self.own_address
+    }
+}
+
+pub struct EthereumLedgerRedisStoreBuilder {
+    redis_store_builder: EngineRedisStoreBuilder,
+}
+
+impl EthereumLedgerRedisStoreBuilder {
+    pub fn new(redis_uri: ConnectionInfo) -> Self {
+        EthereumLedgerRedisStoreBuilder {
+            redis_store_builder: EngineRedisStoreBuilder::new(redis_uri),
+        }
+    }
+
+    pub fn connect(&self) -> impl Future<Item = EthereumLedgerRedisStore, Error = ()> {
+        self.redis_store_builder
+            .connect()
+            .and_then(move |redis_store| {
+                let connection = redis_store.connection.clone();
+                Ok(EthereumLedgerRedisStore {
+                    redis_store,
+                    connection,
+                })
+            })
+    }
+}
+
+/// An Ethereum Store that uses Redis as its underlying database.
+///
+/// This store saves all Ethereum Ledger data for the Ethereum Settlement engine
+#[derive(Clone)]
+pub struct EthereumLedgerRedisStore {
+    redis_store: EngineRedisStore,
+    connection: SharedConnection,
+}
+
+impl EthereumLedgerRedisStore {
+    pub fn new(redis_store: EngineRedisStore) -> Self {
+        let connection = redis_store.connection.clone();
+        EthereumLedgerRedisStore {
+            redis_store,
+            connection,
+        }
+    }
+}
+
+impl EthereumStore for EthereumLedgerRedisStore {
+    type Account = Account;
+
+    fn load_account_addresses(
+        &self,
+        account_ids: Vec<<Self::Account as AccountTrait>::AccountId>,
+    ) -> Box<dyn Future<Item = Vec<EthereumAddresses>, Error = ()> + Send> {
+        debug!("Loading account addresses {:?}", account_ids);
+        let mut pipe = redis::pipe();
+        for account_id in account_ids.iter() {
+            pipe.hgetall(ethereum_ledger_key(*account_id));
+        }
+        Box::new(
+            pipe.query_async(self.connection.clone())
+                .map_err(move |err| {
+                    error!(
+                        "Error the addresses for accounts: {:?} {:?}",
+                        account_ids, err
+                    )
+                })
+                .and_then(
+                    move |(_conn, addresses): (_, Vec<HashMap<String, Vec<u8>>>)| {
+                        debug!("Loaded account addresses {:?}", addresses);
+                        let mut ret = Vec::with_capacity(addresses.len());
+                        for addr in &addresses {
+                            let own_address = if let Some(own_address) = addr.get("own_address") {
+                                own_address
+                            } else {
+                                return err(());
+                            };
+                            let own_address = EthAddress::from(&own_address[..]);
+
+                            let token_address =
+                                if let Some(token_address) = addr.get("token_address") {
+                                    token_address
+                                } else {
+                                    return err(());
+                                };
+                            let token_address = if token_address.len() == 20 {
+                                Some(EthAddress::from(&token_address[..]))
+                            } else {
+                                None
+                            };
+                            ret.push(EthereumAddresses {
+                                own_address,
+                                token_address,
+                            });
+                        }
+                        ok(ret)
+                    },
+                ),
+        )
+    }
+
+    fn save_account_addresses(
+        &self,
+        data: HashMap<<Self::Account as AccountTrait>::AccountId, EthereumAddresses>,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        let mut pipe = redis::pipe();
+        for (account_id, d) in data {
+            let token_address = if let Some(token_address) = d.token_address {
+                token_address.to_vec()
+            } else {
+                vec![]
+            };
+            let acc_id = ethereum_ledger_key(account_id);
+            let addrs = &[
+                ("own_address", d.own_address.to_vec()),
+                ("token_address", token_address),
+            ];
+            pipe.hset_multiple(acc_id, addrs).ignore();
+            pipe.set(addrs_to_key(d), account_id).ignore();
+        }
+        Box::new(
+            pipe.query_async(self.connection.clone())
+                .map_err(move |err| error!("Error saving account data: {:?}", err))
+                .and_then(move |(_conn, _ret): (_, Value)| Ok(())),
+        )
+    }
+
+    fn save_recently_observed_block(
+        &self,
+        block: U256,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        let mut pipe = redis::pipe();
+        pipe.set(RECENTLY_OBSERVED_BLOCK_KEY, block.low_u64())
+            .ignore();
+        Box::new(
+            pipe.query_async(self.connection.clone())
+                .map_err(move |err| {
+                    error!("Error saving last observed block {:?}: {:?}", block, err)
+                })
+                .and_then(move |(_conn, _ret): (_, Value)| Ok(())),
+        )
+    }
+
+    fn load_recently_observed_block(&self) -> Box<dyn Future<Item = U256, Error = ()> + Send> {
+        let mut pipe = redis::pipe();
+        pipe.get(RECENTLY_OBSERVED_BLOCK_KEY);
+        Box::new(
+            pipe.query_async(self.connection.clone())
+                .map_err(move |err| error!("Error loading last observed block: {:?}", err))
+                .and_then(move |(_conn, block): (_, Vec<u64>)| {
+                    if !block.is_empty() {
+                        let block = U256::from(block[0]);
+                        ok(block)
+                    } else {
+                        ok(U256::from(0))
+                    }
+                }),
+        )
+    }
+
+    fn load_account_id_from_address(
+        &self,
+        eth_address: EthereumAddresses,
+    ) -> Box<dyn Future<Item = <Self::Account as AccountTrait>::AccountId, Error = ()> + Send> {
+        let mut pipe = redis::pipe();
+        pipe.get(addrs_to_key(eth_address));
+        Box::new(
+            pipe.query_async(self.connection.clone())
+                .map_err(move |err| error!("Error loading account data: {:?}", err))
+                .and_then(move |(_conn, account_id): (_, Vec<u64>)| ok(account_id[0])),
+        )
+    }
+
+    fn check_if_tx_processed(
+        &self,
+        tx_hash: H256,
+    ) -> Box<dyn Future<Item = bool, Error = ()> + Send> {
+        Box::new(
+            cmd("EXISTS")
+                .arg(ethereum_transactions_key(tx_hash))
+                .query_async(self.connection.clone())
+                .map_err(move |err| error!("Error loading account data: {:?}", err))
+                .and_then(move |(_conn, ret): (_, bool)| Ok(ret)),
+        )
+    }
+
+    fn mark_tx_processed(&self, tx_hash: H256) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        Box::new(
+            cmd("SETNX")
+                .arg(ethereum_transactions_key(tx_hash))
+                .arg(true)
+                .query_async(self.connection.clone())
+                .map_err(move |err| error!("Error loading account data: {:?}", err))
+                .and_then(
+                    move |(_conn, ret): (_, bool)| {
+                        if ret {
+                            ok(())
+                        } else {
+                            err(())
+                        }
+                    },
+                ),
+        )
+    }
+}
+
+fn addrs_to_key(address: EthereumAddresses) -> String {
+    let token_address = if let Some(token_address) = address.token_address {
+        token_address.to_string()
+    } else {
+        "null".to_string()
+    };
+    format!(
+        "account:{}:{}",
+        address.own_address.to_string(),
+        token_address
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::test_helpers::store_helpers::{
+        block_on, test_eth_store as test_store,
+    };
+    use super::*;
+    use std::iter::FromIterator;
+    use std::str::FromStr;
+
+    #[test]
+    fn saves_and_loads_ethereum_addreses_properly() {
+        block_on(test_store().and_then(|(store, context)| {
+            let account_ids = vec![30, 42];
+            let account_addresses = vec![
+                EthereumAddresses {
+                    own_address: EthAddress::from_str("3cdb3d9e1b74692bb1e3bb5fc81938151ca64b02")
+                        .unwrap(),
+                    token_address: Some(
+                        EthAddress::from_str("c92be489639a9c61f517bd3b955840fa19bc9b7c").unwrap(),
+                    ),
+                },
+                EthereumAddresses {
+                    own_address: EthAddress::from_str("2fcd07047c209c46a767f8338cb0b14955826826")
+                        .unwrap(),
+                    token_address: None,
+                },
+            ];
+            let input = HashMap::from_iter(vec![
+                (account_ids[0], account_addresses[0]),
+                (account_ids[1], account_addresses[1]),
+            ]);
+            store
+                .save_account_addresses(input)
+                .map_err(|err| eprintln!("Redis error: {:?}", err))
+                .and_then(move |_| {
+                    store
+                        .load_account_addresses(account_ids.clone())
+                        .map_err(|err| eprintln!("Redis error: {:?}", err))
+                        .and_then(move |data| {
+                            assert_eq!(data[0], account_addresses[0]);
+                            assert_eq!(data[1], account_addresses[1]);
+                            let _ = context;
+                            store
+                                .load_account_id_from_address(account_addresses[0])
+                                .map_err(|err| eprintln!("Redis error: {:?}", err))
+                                .and_then(move |acc_id| {
+                                    assert_eq!(acc_id, account_ids[0]);
+                                    let _ = context;
+                                    store
+                                        .load_account_id_from_address(account_addresses[1])
+                                        .map_err(|err| eprintln!("Redis error: {:?}", err))
+                                        .and_then(move |acc_id| {
+                                            assert_eq!(acc_id, account_ids[1]);
+                                            let _ = context;
+                                            Ok(())
+                                        })
+                                })
+                        })
+                })
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn saves_and_loads_last_observed_data_properly() {
+        block_on(test_store().and_then(|(store, context)| {
+            let block = U256::from(2);
+            store
+                .save_recently_observed_block(block)
+                .map_err(|err| eprintln!("Redis error: {:?}", err))
+                .and_then(move |_| {
+                    store
+                        .load_recently_observed_block()
+                        .map_err(|err| eprintln!("Redis error: {:?}", err))
+                        .and_then(move |data| {
+                            assert_eq!(data, block);
+                            let _ = context;
+                            Ok(())
+                        })
+                })
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn saves_tx_hashes_properly() {
+        block_on(test_store().and_then(|(store, context)| {
+            let tx_hash =
+                H256::from("0xb28675771f555adf614f1401838b9fffb43bc285387679bcbd313a8dc5bdc00e");
+            store
+                .mark_tx_processed(tx_hash)
+                .map_err(|err| eprintln!("Redis error: {:?}", err))
+                .and_then(move |_| {
+                    store
+                        .check_if_tx_processed(tx_hash)
+                        .map_err(|err| eprintln!("Redis error: {:?}", err))
+                        .and_then(move |seen2| {
+                            assert_eq!(seen2, true);
+                            let _ = context;
+                            Ok(())
+                        })
+                })
+        }))
+        .unwrap()
+    }
+}

--- a/crates/interledger-settlement-engines/src/stores/redis_store_common.rs
+++ b/crates/interledger-settlement-engines/src/stores/redis_store_common.rs
@@ -1,0 +1,156 @@
+use crate::stores::{IdempotentEngineData, IdempotentEngineStore};
+use bytes::Bytes;
+use futures::{future::result, Future};
+use http::StatusCode;
+use redis::{self, cmd, r#async::SharedConnection, Client, ConnectionInfo, PipelineCommands};
+use std::collections::HashMap as SlowHashMap;
+use std::str::FromStr;
+
+use log::{debug, error, trace};
+
+pub struct EngineRedisStoreBuilder {
+    redis_uri: ConnectionInfo,
+}
+
+impl EngineRedisStoreBuilder {
+    pub fn new(redis_uri: ConnectionInfo) -> Self {
+        EngineRedisStoreBuilder { redis_uri }
+    }
+
+    pub fn connect(&self) -> impl Future<Item = EngineRedisStore, Error = ()> {
+        result(Client::open(self.redis_uri.clone()))
+            .map_err(|err| error!("Error creating Redis client: {:?}", err))
+            .and_then(|client| {
+                debug!("Connected to redis: {:?}", client);
+                client
+                    .get_shared_async_connection()
+                    .map_err(|err| error!("Error connecting to Redis: {:?}", err))
+            })
+            .and_then(move |connection| Ok(EngineRedisStore { connection }))
+    }
+}
+
+/// A Store that uses Redis as its underlying database.
+///
+/// This store has functionality to handle idempotent data and should be
+/// composed in the stores of other Settlement Engines.
+#[derive(Clone)]
+pub struct EngineRedisStore {
+    pub connection: SharedConnection,
+}
+
+impl IdempotentEngineStore for EngineRedisStore {
+    fn load_idempotent_data(
+        &self,
+        idempotency_key: String,
+    ) -> Box<dyn Future<Item = IdempotentEngineData, Error = ()> + Send> {
+        let idempotency_key_clone = idempotency_key.clone();
+        Box::new(
+            cmd("HGETALL")
+                .arg(idempotency_key.clone())
+                .query_async(self.connection.clone())
+                .map_err(move |err| {
+                    error!(
+                        "Error loading idempotency key {}: {:?}",
+                        idempotency_key_clone, err
+                    )
+                })
+                .and_then(
+                    move |(_connection, ret): (_, SlowHashMap<String, String>)| {
+                        if let (Some(status_code), Some(data), Some(input_hash_slice)) = (
+                            ret.get("status_code"),
+                            ret.get("data"),
+                            ret.get("input_hash"),
+                        ) {
+                            trace!("Loaded idempotency key {:?} - {:?}", idempotency_key, ret);
+                            let mut input_hash: [u8; 32] = Default::default();
+                            input_hash.copy_from_slice(input_hash_slice.as_ref());
+                            Ok((
+                                StatusCode::from_str(status_code).unwrap(),
+                                Bytes::from(data.clone()),
+                                input_hash,
+                            ))
+                        } else {
+                            Err(())
+                        }
+                    },
+                ),
+        )
+    }
+
+    fn save_idempotent_data(
+        &self,
+        idempotency_key: String,
+        input_hash: [u8; 32],
+        status_code: StatusCode,
+        data: Bytes,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        let mut pipe = redis::pipe();
+        pipe.atomic()
+            .cmd("HMSET") // cannot use hset_multiple since data and status_code have different types
+            .arg(&idempotency_key)
+            .arg("status_code")
+            .arg(status_code.as_u16())
+            .arg("data")
+            .arg(data.as_ref())
+            .arg("input_hash")
+            .arg(&input_hash)
+            .ignore()
+            .expire(&idempotency_key, 86400)
+            .ignore();
+        Box::new(
+            pipe.query_async(self.connection.clone())
+                .map_err(|err| error!("Error caching: {:?}", err))
+                .and_then(move |(_connection, _): (_, Vec<String>)| {
+                    trace!(
+                        "Cached {:?}: {:?}, {:?}",
+                        idempotency_key,
+                        status_code,
+                        data,
+                    );
+                    Ok(())
+                }),
+        )
+    }
+}
+
+// add tests for idempotency from other store
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::store_helpers::{block_on, test_store, IDEMPOTENCY_KEY};
+    use super::*;
+
+    #[test]
+    fn saves_and_loads_idempotency_key_data_properly() {
+        block_on(test_store().and_then(|(store, context)| {
+            let input_hash: [u8; 32] = Default::default();
+            store
+                .save_idempotent_data(
+                    IDEMPOTENCY_KEY.clone(),
+                    input_hash,
+                    StatusCode::OK,
+                    Bytes::from("TEST"),
+                )
+                .map_err(|err| eprintln!("Redis error: {:?}", err))
+                .and_then(move |_| {
+                    store
+                        .load_idempotent_data(IDEMPOTENCY_KEY.clone())
+                        .map_err(|err| eprintln!("Redis error: {:?}", err))
+                        .and_then(move |data1| {
+                            assert_eq!(data1, (StatusCode::OK, Bytes::from("TEST"), input_hash));
+                            let _ = context;
+
+                            store
+                                .load_idempotent_data("asdf".to_string())
+                                .map_err(|err| eprintln!("Redis error: {:?}", err))
+                                .and_then(move |_data2| {
+                                    assert_eq!(_data2.0, StatusCode::OK);
+                                    let _ = context;
+                                    Ok(())
+                                })
+                        })
+                })
+        }))
+        .unwrap_err() // the second idempotent load fails
+    }
+}

--- a/crates/interledger-settlement-engines/src/stores/test_helpers/mod.rs
+++ b/crates/interledger-settlement-engines/src/stores/test_helpers/mod.rs
@@ -1,0 +1,2 @@
+pub mod redis_helpers;
+pub mod store_helpers;

--- a/crates/interledger-settlement-engines/src/stores/test_helpers/redis_helpers.rs
+++ b/crates/interledger-settlement-engines/src/stores/test_helpers/redis_helpers.rs
@@ -1,0 +1,188 @@
+// Copied from https://github.com/mitsuhiko/redis-rs/blob/9a1777e8a90c82c315a481cdf66beb7d69e681a2/tests/support/mod.rs
+#![allow(dead_code)]
+
+extern crate futures;
+extern crate net2;
+extern crate os_type;
+extern crate rand;
+
+use redis;
+
+use std::env;
+use std::fs;
+use std::process;
+use std::thread::sleep;
+use std::time::Duration;
+
+use std::path::PathBuf;
+
+use self::futures::Future;
+
+use redis::RedisError;
+
+#[derive(PartialEq)]
+enum ServerType {
+    Tcp,
+    Unix,
+}
+
+pub struct RedisServer {
+    pub process: process::Child,
+    addr: redis::ConnectionAddr,
+}
+
+impl ServerType {
+    fn get_intended() -> ServerType {
+        match env::var("REDISRS_SERVER_TYPE")
+            .ok()
+            .as_ref()
+            .map(|x| &x[..])
+        {
+            // Default to unix unlike original version
+            Some("tcp") => ServerType::Tcp,
+            _ => ServerType::Unix,
+        }
+    }
+}
+
+impl Default for RedisServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RedisServer {
+    pub fn new() -> RedisServer {
+        let server_type = ServerType::get_intended();
+        let mut cmd = process::Command::new("redis-server");
+
+        cmd.stdout(process::Stdio::null())
+            .stderr(process::Stdio::null());
+
+        let addr = match server_type {
+            ServerType::Tcp => {
+                // this is technically a race but we can't do better with
+                // the tools that redis gives us :(
+                let listener = net2::TcpBuilder::new_v4()
+                    .unwrap()
+                    .reuse_address(true)
+                    .unwrap()
+                    .bind("127.0.0.1:0")
+                    .unwrap()
+                    .listen(1)
+                    .unwrap();
+                let server_port = listener.local_addr().unwrap().port();
+                cmd.arg("--port")
+                    .arg(server_port.to_string())
+                    .arg("--bind")
+                    .arg("127.0.0.1");
+                redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), server_port)
+            }
+            ServerType::Unix => {
+                let (a, b) = rand::random::<(u64, u64)>();
+                let path = format!("/tmp/redis-rs-test-{}-{}.sock", a, b);
+                cmd.arg("--port").arg("0").arg("--unixsocket").arg(&path);
+                redis::ConnectionAddr::Unix(PathBuf::from(&path))
+            }
+        };
+
+        let process = cmd.spawn().unwrap();
+        RedisServer { process, addr }
+    }
+
+    pub fn wait(&mut self) {
+        self.process.wait().unwrap();
+    }
+
+    pub fn get_client_addr(&self) -> &redis::ConnectionAddr {
+        &self.addr
+    }
+
+    pub fn stop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+        if let redis::ConnectionAddr::Unix(ref path) = *self.get_client_addr() {
+            fs::remove_file(&path).ok();
+        }
+    }
+}
+
+impl Drop for RedisServer {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+pub struct TestContext {
+    pub server: RedisServer,
+    pub client: redis::Client,
+}
+
+impl Default for TestContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestContext {
+    pub fn new() -> TestContext {
+        let server = RedisServer::new();
+
+        let client = redis::Client::open(redis::ConnectionInfo {
+            addr: Box::new(server.get_client_addr().clone()),
+            db: 0,
+            passwd: None,
+        })
+        .unwrap();
+        let con;
+
+        let millisecond = Duration::from_millis(1);
+        loop {
+            match client.get_connection() {
+                Err(err) => {
+                    if err.is_connection_refusal() {
+                        sleep(millisecond);
+                    } else {
+                        panic!("Could not connect: {}", err);
+                    }
+                }
+                Ok(x) => {
+                    con = x;
+                    break;
+                }
+            }
+        }
+        redis::cmd("FLUSHDB").execute(&con);
+
+        TestContext { server, client }
+    }
+
+    // This one was added and not in the original file
+    pub fn get_client_connection_info(&self) -> redis::ConnectionInfo {
+        redis::ConnectionInfo {
+            addr: Box::new(self.server.get_client_addr().clone()),
+            db: 0,
+            passwd: None,
+        }
+    }
+
+    pub fn connection(&self) -> redis::Connection {
+        self.client.get_connection().unwrap()
+    }
+
+    pub fn async_connection(&self) -> impl Future<Item = redis::r#async::Connection, Error = ()> {
+        self.client
+            .get_async_connection()
+            .map_err(|err| panic!(err))
+    }
+
+    pub fn stop_server(&mut self) {
+        self.server.stop();
+    }
+
+    pub fn shared_async_connection(
+        &self,
+    ) -> impl Future<Item = redis::r#async::SharedConnection, Error = RedisError> {
+        self.client.get_shared_async_connection()
+    }
+}

--- a/crates/interledger-settlement-engines/src/stores/test_helpers/store_helpers.rs
+++ b/crates/interledger-settlement-engines/src/stores/test_helpers/store_helpers.rs
@@ -1,0 +1,39 @@
+use super::super::redis_ethereum_ledger::EthereumLedgerRedisStore;
+use super::super::redis_store_common::{EngineRedisStore, EngineRedisStoreBuilder};
+
+use super::redis_helpers::*;
+use env_logger;
+use futures::Future;
+use tokio::runtime::Runtime;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref IDEMPOTENCY_KEY: String = String::from("abcd");
+}
+
+pub fn test_store() -> impl Future<Item = (EngineRedisStore, TestContext), Error = ()> {
+    let context = TestContext::new();
+    EngineRedisStoreBuilder::new(context.get_client_connection_info())
+        .connect()
+        .and_then(|store| Ok((store, context)))
+}
+
+pub fn test_eth_store() -> impl Future<Item = (EthereumLedgerRedisStore, TestContext), Error = ()> {
+    let context = TestContext::new();
+    EngineRedisStoreBuilder::new(context.get_client_connection_info())
+        .connect()
+        .and_then(|redis_store| Ok((EthereumLedgerRedisStore::new(redis_store), context)))
+}
+
+pub fn block_on<F>(f: F) -> Result<F::Item, F::Error>
+where
+    F: Future + Send + 'static,
+    F::Item: Send,
+    F::Error: Send,
+{
+    // Only run one test at a time
+    let _ = env_logger::try_init();
+    let mut runtime = Runtime::new().unwrap();
+    runtime.block_on(f)
+}

--- a/crates/interledger-settlement/Cargo.toml
+++ b/crates/interledger-settlement/Cargo.toml
@@ -25,9 +25,10 @@ lazy_static = "1.3.0"
 uuid = "0.7.4"
 rand = "0.6.5"
 ring = "0.14.6"
+tokio-retry = "0.2.0"
+tokio = "0.1.20"
 
 [dev-dependencies]
 parking_lot = "0.8.0"
 mockito = "0.17.1"
-tokio = "0.1.20"
 env_logger = "0.6.1"

--- a/crates/interledger-settlement/src/api.rs
+++ b/crates/interledger-settlement/src/api.rs
@@ -1,7 +1,7 @@
-use super::{SettlementAccount, SettlementStore};
+use super::{IdempotentData, IdempotentStore, SettlementAccount, SettlementStore, SE_ILP_ADDRESS};
 use bytes::Bytes;
 use futures::{
-    future::{ok, result, Either},
+    future::{err, ok, result, Either},
     Future,
 };
 use hyper::{Response, StatusCode};
@@ -9,13 +9,14 @@ use interledger_ildcp::IldcpAccount;
 use interledger_packet::PrepareBuilder;
 use interledger_service::{AccountStore, OutgoingRequest, OutgoingService};
 use interledger_service_util::{Convert, ConvertDetails};
-use log::error;
+use log::{debug, error};
 use ring::digest::{digest, SHA256};
 use std::{
     marker::PhantomData,
     str::{self, FromStr},
     time::{Duration, SystemTime},
 };
+use tokio::executor::spawn;
 use tower_web::{net::ConnectionStream, ServiceBuilder};
 
 static PEER_PROTOCOL_CONDITION: [u8; 32] = [
@@ -28,6 +29,7 @@ struct SettlementData {
     amount: u64,
 }
 
+#[derive(Clone)]
 pub struct SettlementApi<S, O, A> {
     outgoing_handler: O,
     store: S,
@@ -37,7 +39,7 @@ pub struct SettlementApi<S, O, A> {
 impl_web! {
     impl<S, O, A> SettlementApi<S, O, A>
     where
-        S: SettlementStore<Account = A> + AccountStore<Account = A> + Clone + Send + Sync + 'static,
+        S: SettlementStore<Account = A> + IdempotentStore + AccountStore<Account = A> + Clone + Send + Sync + 'static,
         O: OutgoingService<A> + Clone + Send + Sync + 'static,
         A: SettlementAccount + IldcpAccount + Send + Sync + 'static,
     {
@@ -49,237 +51,218 @@ impl_web! {
             }
         }
 
+        // Helper function that returns any idempotent data that corresponds to a
+        // provided idempotency key. It fails if the hash of the input that
+        // generated the idempotent data does not match the hash of the provided input.
         fn check_idempotency(
             &self,
-            idempotency_key: Option<String>,
+            idempotency_key: String,
             input_hash: [u8; 32],
-        ) -> impl Future<Item = Option<(StatusCode, Bytes)>, Error = (StatusCode, String)> {
-            if let Some(idempotency_key) = idempotency_key {
-                Either::A(self.store.load_idempotent_data(idempotency_key.clone())
-                .map_err(move |err| {
-                    let err = format!("Couldn't connect to store {:?}", err);
-                    error!("{}", err);
-                    (StatusCode::from_u16(500).unwrap(), err)
-                }).and_then(move |ret: Option<(StatusCode, Bytes, [u8; 32])>| {
-                        if let Some(d) = ret {
-                            if d.2 != input_hash {
-                                // Stripe CONFLICT status code
-                                return Err((StatusCode::from_u16(409).unwrap(), "Provided idempotency key is tied to other input".to_string()))
-                            }
-                            if d.0.is_success() {
-                                return Ok(Some((d.0, d.1)))
-                            } else {
-                                return Err((d.0, String::from_utf8_lossy(&d.1).to_string()))
-                            }
-                        }
-                        Ok(None)
+        ) -> impl Future<Item = (StatusCode, Bytes), Error = String> {
+            self.store
+                .load_idempotent_data(idempotency_key.clone())
+                .map_err(move |_| {
+                    let error_msg = "Couldn' load idempotent data".to_owned();
+                    error!("{}", error_msg);
+                    error_msg
+                })
+                .and_then(move |ret: IdempotentData| {
+                    if ret.2 == input_hash {
+                        Ok((ret.0, ret.1))
+                    } else {
+                        Ok((StatusCode::from_u16(409).unwrap(), Bytes::from(&b"Provided idempotency key is tied to other input"[..])))
                     }
-                ))
+                })
+        }
+
+        fn make_idempotent_call<F>(&self, f: F, input_hash: [u8; 32], idempotency_key: Option<String>) -> impl Future<Item = Response<Bytes>, Error = Response<String>>
+        where F: FnOnce() -> Box<dyn Future<Item = (StatusCode, Bytes), Error = (StatusCode, String)> + Send> {
+            let store = self.store.clone();
+            if let Some(idempotency_key) = idempotency_key {
+                // If there an idempotency key was provided, check idempotency
+                // and the key was not present or conflicting with an existing
+                // key, perform the call and save the idempotent return data
+                Either::A(
+                    self.check_idempotency(idempotency_key.clone(), input_hash)
+                    .then(move |ret: Result<(StatusCode, Bytes), String>| {
+                        if let Ok(ret) = ret {
+                            if ret.0.is_success() {
+                                let resp = Response::builder().status(ret.0).body(ret.1).unwrap();
+                                return Either::A(Either::A(ok(resp)))
+                            } else {
+                                let resp = Response::builder().status(ret.0).body(String::from_utf8_lossy(&ret.1).to_string()).unwrap();
+                                return Either::A(Either::B(err(resp)))
+
+                            }
+                        } else {
+                            Either::B(
+                                f()
+                                .map_err({let store = store.clone(); let idempotency_key = idempotency_key.clone(); move |ret: (StatusCode, String)| {
+                                    let status_code = ret.0;
+                                    let data = Bytes::from(ret.1.clone());
+                                    spawn(store.save_idempotent_data(idempotency_key, input_hash, status_code, data));
+                                    Response::builder().status(status_code).body(ret.1).unwrap()
+                                }})
+                                .and_then(move |ret: (StatusCode, Bytes)| {
+                                    store.save_idempotent_data(idempotency_key, input_hash, ret.0, ret.1.clone())
+                                    .map_err({let ret = ret.clone(); move |_| {
+                                        Response::builder().status(ret.0).body(String::from_utf8_lossy(&ret.1).to_string()).unwrap()
+                                    }}).and_then(move |_| {
+                                        Ok(Response::builder().status(ret.0).body(ret.1).unwrap())
+                                    })
+                                })
+                            )
+                        }
+                    })
+                )
             } else {
-                Either::B(ok(None))
+                // otherwise just make the call w/o any idempotency saves
+                Either::B(
+                    f()
+                    .map_err(move |ret: (StatusCode, String)| {
+                        Response::builder().status(ret.0).body(ret.1).unwrap()
+                    })
+                    .and_then(move |ret: (StatusCode, Bytes)| {
+                        Ok(Response::builder().status(ret.0).body(ret.1).unwrap())
+                    })
+                )
             }
         }
 
         #[post("/accounts/:account_id/settlement")]
         fn receive_settlement(&self, account_id: String, body: SettlementData, idempotency_key: Option<String>) -> impl Future<Item = Response<Bytes>, Error = Response<String>> {
-            let amount = body.amount;
-            let store = self.store.clone();
+            debug!("Receive settlement called with {:?} {:?}", account_id, body);
 
             let input = format!("{}{:?}", account_id, body);
             let input_hash = get_hash_of(input.as_ref());
 
-            self.check_idempotency(idempotency_key.clone(), input_hash).map_err(|res| {
-                Response::builder().status(res.0).body(res.1).unwrap()
-            })
-            .and_then(move |ret: Option<(StatusCode, Bytes)>| {
-                if let Some(d) = ret {
-                    return Either::A(ok(Response::builder().status(d.0).body(d.1).unwrap()));
-                }
-                Either::B(
-                    result(A::AccountId::from_str(&account_id)
-                    .map_err({
-                        let store = store.clone();
-                        let idempotency_key = idempotency_key.clone();
-                        move |_err| {
-                        let error_msg = format!("Unable to parse account id: {}", account_id);
-                        error!("{}", error_msg);
-                        let status_code = StatusCode::from_u16(400).unwrap();
-                        let data = Bytes::from(error_msg.clone());
-                        if let Some(idempotency_key) = idempotency_key {
-                            store.save_idempotent_data(idempotency_key, input_hash, status_code, data);
-                        }
-                        Response::builder().status(400).body(error_msg).unwrap()
-                    }}))
-                    .and_then({
-                        let store = store.clone();
-                        let idempotency_key = idempotency_key.clone();
-                        move |account_id| {
-                        store.get_accounts(vec![account_id])
-                        .map_err({
-                            let store = store.clone();
-                            let idempotency_key = idempotency_key.clone();
-                            move |_err| {
-                            let error_msg = format!("Error getting account: {}", account_id);
-                            error!("{}", error_msg);
+            let self_clone = self.clone();
+            let idempotency_key_clone = idempotency_key.clone();
+            let f = move || self_clone.do_receive_settlement(account_id, body, idempotency_key_clone);
+            self.make_idempotent_call(f, input_hash, idempotency_key)
+        }
 
-                            let status_code = StatusCode::from_u16(404).unwrap();
-                            let data = Bytes::from(error_msg.clone());
-                            if let Some(idempotency_key) = idempotency_key {
-                                store.save_idempotent_data(idempotency_key.clone(), input_hash, status_code, data);
-                            }
-                            Response::builder().status(404).body(error_msg).unwrap()
-                        }})
-                    }})
-                    .and_then({
-                        let store = store.clone();
-                        let idempotency_key = idempotency_key.clone();
-                        move |accounts| {
-                        let account = &accounts[0];
-                        if let Some(settlement_engine) = account.settlement_engine_details() {
-                            Ok((account.clone(), settlement_engine))
-                        } else {
-                            let error_msg = format!("Account {} does not have settlement engine details configured. Cannot handle incoming settlement", account.id());
-                            error!("{}", error_msg);
-                            if let Some(idempotency_key) = idempotency_key {
-                                store.save_idempotent_data(idempotency_key, input_hash, StatusCode::from_u16(404).unwrap(), Bytes::from(error_msg.clone()));
-                            }
-                            Err(Response::builder().status(404).body(error_msg).unwrap())
-                        }
-                    }})
-                    .and_then({
-                        let store = store.clone();
-                        let idempotency_key = idempotency_key.clone();
-                        move |(account, settlement_engine)| {
-                        let account_id = account.id();
-                        let amount = amount.normalize_scale(ConvertDetails {
-                            from: account.asset_scale(),
-                            to: settlement_engine.asset_scale
-                        });
-                        store.update_balance_for_incoming_settlement(account_id, amount, idempotency_key)
-                            .map_err(move |_| {
-                                let err = format!("Error updating balance of account: {} for incoming settlement of amount: {}", account_id, amount);
-                                error!("{}", err);
-                                Response::builder().status(500).body(err).unwrap()
-                        })
-                    }}).and_then({
-                        let store = store.clone();
-                        let idempotency_key = idempotency_key.clone();
-                        move |_| {
-                        let ret = Bytes::from("Success");
-                        if let Some(idempotency_key) = idempotency_key {
-                            store.save_idempotent_data(idempotency_key, input_hash, StatusCode::OK, ret.clone());
-                        }
-                        ok(())
-                        .and_then(|_| Ok(Response::builder().status(StatusCode::OK).body(ret).unwrap()))
-                    }}))
+        fn do_receive_settlement(&self, account_id: String, body: SettlementData, idempotency_key: Option<String>) -> Box<dyn Future<Item = (StatusCode, Bytes), Error = (StatusCode, String)> + Send> {
+            let amount = body.amount;
+            let store = self.store.clone();
+            Box::new(result(A::AccountId::from_str(&account_id)
+            .map_err(move |_err| {
+                let error_msg = format!("Unable to parse account id: {}", account_id);
+                error!("{}", error_msg);
+                (StatusCode::from_u16(400).unwrap(), error_msg)
+            }))
+            .and_then({
+                let store = store.clone();
+                move |account_id| {
+                store.get_accounts(vec![account_id])
+                .map_err(move |_err| {
+                    let error_msg = format!("Error getting account: {}", account_id);
+                    error!("{}", error_msg);
+                    (StatusCode::from_u16(404).unwrap(), error_msg)
                 })
+            }})
+            .and_then(move |accounts| {
+                let account = &accounts[0];
+                if let Some(settlement_engine) = account.settlement_engine_details() {
+                    Ok((account.clone(), settlement_engine))
+                } else {
+                    let error_msg = format!("Account {} does not have settlement engine details configured. Cannot handle incoming settlement", account.id());
+                    error!("{}", error_msg);
+                    Err((StatusCode::from_u16(404).unwrap(), error_msg))
+                }
+            })
+            .and_then(move |(account, settlement_engine)| {
+                let account_id = account.id();
+                let amount = amount.normalize_scale(ConvertDetails {
+                    from: account.asset_scale(),
+                    to: settlement_engine.asset_scale
+                });
+                store.update_balance_for_incoming_settlement(account_id, amount, idempotency_key)
+                .map_err(move |_| {
+                    let error_msg = format!("Error updating balance of account: {} for incoming settlement of amount: {}", account_id, amount);
+                    error!("{}", error_msg);
+                    (StatusCode::from_u16(500).unwrap(), error_msg)
+                })
+            }).and_then(move |_| {
+                let ret = Bytes::from("Success");
+                Ok((StatusCode::OK, ret))
+            }))
         }
 
         // Gets called by our settlement engine, forwards the request outwards
         // until it reaches the peer's settlement engine. Extract is not
         // implemented for Bytes unfortunately.
-        #[post("/accounts/:account_id/messages")]
-        fn send_outgoing_message(&self, account_id: String, body: Vec<u8>, idempotency_key: Option<String>)-> impl Future<Item = Response<Bytes>, Error = Response<String>> {
+       #[post("/accounts/:account_id/messages")]
+       fn send_outgoing_message(&self, account_id: String, body: Vec<u8>, idempotency_key: Option<String>)-> impl Future<Item = Response<Bytes>, Error = Response<String>> {
+
+           let input = format!("{}{:?}", account_id, body);
+           let input_hash = get_hash_of(input.as_ref());
+
+            let self_clone = self.clone();
+            let f = move || self_clone.do_send_outgoing_message(account_id, body);
+            self.make_idempotent_call(f, input_hash, idempotency_key)
+       }
+
+        fn do_send_outgoing_message(&self, account_id: String, body: Vec<u8>) -> Box<dyn Future<Item = (StatusCode, Bytes), Error = (StatusCode, String)> + Send> {
             let store = self.store.clone();
             let mut outgoing_handler = self.outgoing_handler.clone();
-
-            let input = format!("{}{:?}", account_id, body);
-            let input_hash = get_hash_of(input.as_ref());
-
-            self.check_idempotency(idempotency_key.clone(), input_hash).map_err(|res| {
-                Response::builder().status(res.0).body(res.1).unwrap()
-            })
-            .and_then(move |ret: Option<(StatusCode, Bytes)>| {
-                if let Some(d) = ret {
-                    return Either::A(ok(Response::builder().status(d.0).body(d.1).unwrap()));
-                }
-                Either::B(
-                result(A::AccountId::from_str(&account_id)
-                .map_err({
-                    let store = store.clone();
-                    let idempotency_key = idempotency_key.clone();
-                    move |_err| {
-                    let error_msg = format!("Unable to parse account id: {}", account_id);
-                    error!("{}", error_msg);
-                    let status_code = StatusCode::from_u16(400).unwrap();
-                    let data = Bytes::from(error_msg.clone());
-                    if let Some(idempotency_key) = idempotency_key {
-                        store.save_idempotent_data(idempotency_key, input_hash, status_code, data);
-                    }
-                    Response::builder().status(400).body(error_msg).unwrap()
-                }}))
-                .and_then({
-                    let store = store.clone();
-                    let idempotency_key = idempotency_key.clone();
-                    move |account_id|
-                store.get_accounts(vec![account_id])
-                .map_err({
-                    move |_| {
-                    let error_msg = format!("Error getting account: {}", account_id);
-                    error!("{}", error_msg);
-                    let status_code = StatusCode::from_u16(404).unwrap();
-                    let data = Bytes::from(error_msg.clone());
-                    if let Some(idempotency_key) = idempotency_key {
-                        store.save_idempotent_data(idempotency_key, input_hash, status_code, data);
-                    }
-                    Response::builder().status(404).body(error_msg).unwrap()
-                }})})
-                .and_then(|accounts| {
-                    let account = &accounts[0];
-                    if let Some(settlement_engine) = account.settlement_engine_details() {
-                        Ok((account.clone(), settlement_engine))
-                    } else {
-                        let err = format!("Account {} has no settlement engine details configured, cannot send a settlement engine message to that account", accounts[0].id());
-                        error!("{}", err);
-                        Err(Response::builder().status(404).body(err).unwrap())
-                    }
-                })
-                .and_then({
-                    let store = store.clone();
-                    let idempotency_key = idempotency_key.clone();
-                    move |(account, settlement_engine)| {
-                    // Send the message to the peer's settlement engine.
-                    // Note that we use dummy values for the `from` and `original_amount`
-                    // because this `OutgoingRequest` will bypass the router and thus will not
-                    // use either of these values. Including dummy values in the rare case where
-                    // we do not need them seems easier than using
-                    // `Option`s all over the place.
-                    outgoing_handler.send_request(OutgoingRequest {
-                        from: account.clone(),
-                        to: account.clone(),
-                        original_amount: 0,
-                        prepare: PrepareBuilder {
-                            destination: settlement_engine.ilp_address,
-                            amount: 0,
-                            expires_at: SystemTime::now() + Duration::from_secs(30),
-                            data: &body,
-                            execution_condition: &PEER_PROTOCOL_CONDITION,
-                        }.build()
-                    })
-                    .map_err({
-                        move |reject| {
-                        let error_msg = format!("Error sending message to peer settlement engine. Packet rejected with code: {}, message: {}", reject.code(), str::from_utf8(reject.message()).unwrap_or_default());
+               Box::new(result(A::AccountId::from_str(&account_id)
+               .map_err(move |_err| {
+                   let error_msg = format!("Unable to parse account id: {}", account_id);
+                   error!("{}", error_msg);
+                   let status_code = StatusCode::from_u16(400).unwrap();
+                   (status_code, error_msg)
+               }))
+               .and_then(move |account_id| {
+                    store.get_accounts(vec![account_id])
+                    .map_err(move |_| {
+                        let error_msg = format!("Error getting account: {}", account_id);
                         error!("{}", error_msg);
-                        if let Some(idempotency_key) = idempotency_key {
-                            store.save_idempotent_data(idempotency_key, input_hash, StatusCode::from_u16(502).unwrap(), Bytes::from(error_msg.clone()));
-                        }
-                        Response::builder().status(502).body(error_msg).unwrap()
-                    }})
-                }})
-                .and_then({
-                    move |fulfill| {
-                    let data = Bytes::from(fulfill.data());
-                    if let Some(idempotency_key) = idempotency_key {
-                        store.save_idempotent_data(idempotency_key, input_hash, StatusCode::OK, data.clone());
-                    }
-                    ok(())
-                    .and_then(|_| Ok(
-                        Response::builder().status(200).body(data).unwrap()
-                    ))
-                }})
-            )})
+                        let status_code = StatusCode::from_u16(404).unwrap();
+                        (status_code, error_msg)
+                    })
+                })
+               .and_then(|accounts| {
+                   let account = &accounts[0];
+                   if account.settlement_engine_details().is_some() {
+                       Ok(account.clone())
+                   } else {
+                       let error_msg = format!("Account {} has no settlement engine details configured, cannot send a settlement engine message to that account", accounts[0].id());
+                       error!("{}", error_msg);
+                       Err((StatusCode::from_u16(404).unwrap(), error_msg))
+                   }
+               })
+               .and_then(move |account| {
+                   // Send the message to the peer's settlement engine.
+                   // Note that we use dummy values for the `from` and `original_amount`
+                   // because this `OutgoingRequest` will bypass the router and thus will not
+                   // use either of these values. Including dummy values in the rare case where
+                   // we do not need them seems easier than using
+                   // `Option`s all over the place.
+                   outgoing_handler.send_request(OutgoingRequest {
+                       from: account.clone(),
+                       to: account.clone(),
+                       original_amount: 0,
+                       prepare: PrepareBuilder {
+                           destination: SE_ILP_ADDRESS.clone(),
+                           amount: 0,
+                           expires_at: SystemTime::now() + Duration::from_secs(30),
+                           data: &body,
+                           execution_condition: &PEER_PROTOCOL_CONDITION,
+                       }.build()
+                   })
+                   .map_err(move |reject| {
+                       let error_msg = format!("Error sending message to peer settlement engine. Packet rejected with code: {}, message: {}", reject.code(), str::from_utf8(reject.message()).unwrap_or_default());
+                       error!("{}", error_msg);
+                       (StatusCode::from_u16(502).unwrap(), error_msg)
+                   })
+               })
+               .and_then(move |fulfill| {
+                   let data = Bytes::from(fulfill.data());
+                   Ok((StatusCode::OK, data))
+               })
+               )
         }
-
         pub fn serve<I>(self, incoming: I) -> impl Future<Item = (), Error = ()>
         where
             I: ConnectionStream,
@@ -392,30 +375,26 @@ mod tests {
             let store = test_store(false, false);
             let api = test_api(store.clone(), false);
 
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id.clone(),
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id.clone(),
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 404);
             assert_eq!(ret.body(), "Account 0 does not have settlement engine details configured. Cannot handle incoming settlement");
 
             // check that it's idempotent
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id,
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id,
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 404);
             assert_eq!(ret.body(), "Account 0 does not have settlement engine details configured. Cannot handle incoming settlement");
 
@@ -435,16 +414,14 @@ mod tests {
             let store = test_store(true, true);
             let api = test_api(store, false);
 
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id,
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id,
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 500);
         }
 
@@ -456,43 +433,37 @@ mod tests {
             let store = test_store(false, true);
             let api = test_api(store.clone(), false);
 
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id.clone(),
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id.clone(),
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 400);
             assert_eq!(ret.body(), "Unable to parse account id: a");
 
             // check that it's idempotent
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id.clone(),
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id.clone(),
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 400);
             assert_eq!(ret.body(), "Unable to parse account id: a");
 
-            let _ret: Response<_> = api
-                .receive_settlement(
-                    id,
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let _ret: Response<_> = block_on(api.receive_settlement(
+                id,
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
 
             let s = store.clone();
             let cache = s.cache.read();
@@ -510,29 +481,25 @@ mod tests {
             let store = TestStore::new(vec![], false);
             let api = test_api(store.clone(), false);
 
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id.clone(),
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id.clone(),
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 404);
             assert_eq!(ret.body(), "Error getting account: 0");
 
-            let ret: Response<_> = api
-                .receive_settlement(
-                    id,
-                    SettlementData {
-                        amount: SETTLEMENT_BODY,
-                    },
-                    IDEMPOTENCY.clone(),
-                )
-                .wait()
-                .unwrap_err(); // Bug that returns Result::OK
+            let ret: Response<_> = block_on(api.receive_settlement(
+                id,
+                SettlementData {
+                    amount: SETTLEMENT_BODY,
+                },
+                IDEMPOTENCY.clone(),
+            ))
+            .unwrap_err();
             assert_eq!(ret.status().as_u16(), 404);
             assert_eq!(ret.body(), "Error getting account: 0");
 
@@ -555,27 +522,24 @@ mod tests {
             let store = test_store(false, true);
             let api = test_api(store.clone(), true);
 
-            let ret: Response<_> = api
-                .send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone()))
+                    .unwrap();
             assert_eq!(ret.status(), StatusCode::OK);
             assert_eq!(ret.body(), &Bytes::from("hello!"));
 
-            let ret: Response<_> = api
-                .send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone()))
+                    .unwrap();
             assert_eq!(ret.status(), StatusCode::OK);
             assert_eq!(ret.body(), &Bytes::from("hello!"));
 
             // Using the same idempotency key with different arguments MUST
             // fail.
             let id2 = "1".to_string();
-            let ret: Response<_> = api
-                .send_outgoing_message(id2.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id2.clone(), vec![], IDEMPOTENCY.clone()))
+                    .unwrap_err();
             assert_eq!(ret.status(), StatusCode::from_u16(409).unwrap());
             assert_eq!(
                 ret.body(),
@@ -584,10 +548,9 @@ mod tests {
 
             let data = vec![0, 1, 2];
             // fails with different account id and data
-            let ret: Response<_> = api
-                .send_outgoing_message(id2, data.clone(), IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id2, data.clone(), IDEMPOTENCY.clone()))
+                    .unwrap_err();
             assert_eq!(ret.status(), StatusCode::from_u16(409).unwrap());
             assert_eq!(
                 ret.body(),
@@ -595,10 +558,8 @@ mod tests {
             );
 
             // fails for same account id but different data
-            let ret: Response<_> = api
-                .send_outgoing_message(id, data, IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id, data, IDEMPOTENCY.clone())).unwrap_err();
             assert_eq!(ret.status(), StatusCode::from_u16(409).unwrap());
             assert_eq!(
                 ret.body(),
@@ -620,16 +581,12 @@ mod tests {
             let store = test_store(false, true);
             let api = test_api(store.clone(), false);
 
-            let ret = api
-                .send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
+            let ret = block_on(api.send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone()))
                 .unwrap_err();
             assert_eq!(ret.status().as_u16(), 502);
 
-            let ret = api
-                .send_outgoing_message(id, vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret =
+                block_on(api.send_outgoing_message(id, vec![], IDEMPOTENCY.clone())).unwrap_err();
             assert_eq!(ret.status().as_u16(), 502);
 
             let s = store.clone();
@@ -649,22 +606,18 @@ mod tests {
             let store = test_store(false, true);
             let api = test_api(store.clone(), true);
 
-            let ret: Response<_> = api
-                .send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone()))
+                    .unwrap_err();
             assert_eq!(ret.status().as_u16(), 400);
 
-            let ret: Response<_> = api
-                .send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone()))
+                    .unwrap_err();
             assert_eq!(ret.status().as_u16(), 400);
 
-            let _ret: Response<_> = api
-                .send_outgoing_message(id, vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let _ret: Response<_> =
+                block_on(api.send_outgoing_message(id, vec![], IDEMPOTENCY.clone())).unwrap_err();
             assert_eq!(ret.status().as_u16(), 400);
 
             let s = store.clone();
@@ -683,16 +636,13 @@ mod tests {
             let store = TestStore::new(vec![], false);
             let api = test_api(store.clone(), true);
 
-            let ret: Response<_> = api
-                .send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id.clone(), vec![], IDEMPOTENCY.clone()))
+                    .unwrap_err();
             assert_eq!(ret.status().as_u16(), 404);
 
-            let ret: Response<_> = api
-                .send_outgoing_message(id, vec![], IDEMPOTENCY.clone())
-                .wait()
-                .unwrap_err();
+            let ret: Response<_> =
+                block_on(api.send_outgoing_message(id, vec![], IDEMPOTENCY.clone())).unwrap_err();
             assert_eq!(ret.status().as_u16(), 404);
 
             let s = store.clone();

--- a/crates/interledger-settlement/src/client.rs
+++ b/crates/interledger-settlement/src/client.rs
@@ -7,6 +7,7 @@ use interledger_ildcp::IldcpAccount;
 use interledger_service_util::{Convert, ConvertDetails};
 use log::{error, trace};
 use reqwest::r#async::Client;
+use serde_json::json;
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -46,9 +47,8 @@ impl SettlementClient {
             let settlement_engine_url_clone = settlement_engine_url.clone();
             let idempotency_uuid = Uuid::new_v4().to_hyphenated().to_string();
             return Either::A(self.http_client.post(settlement_engine_url.clone())
-                .header("Content-Type", "application/octet-stream")
                 .header("Idempotency-Key", idempotency_uuid)
-                .body(amount.to_string())
+                .json(&json!({"amount": amount}))
                 .send()
                 .map_err(move |err| error!("Error sending settlement command to settlement engine {}: {:?}", settlement_engine_url, err))
                 .and_then(move |response| {
@@ -90,7 +90,6 @@ mod tests {
 
         m.assert();
         assert!(ret.is_ok());
-        println!("{:?} RET", ret.unwrap());
     }
 
     #[test]

--- a/crates/interledger-settlement/src/fixtures.rs
+++ b/crates/interledger-settlement/src/fixtures.rs
@@ -12,7 +12,7 @@ pub static SETTLEMENT_BODY: u64 = 100;
 
 lazy_static! {
     pub static ref TEST_ACCOUNT_0: TestAccount =
-        TestAccount::new(0, "http://localhost:1234", "peer.settle.xrp-ledger");
+        TestAccount::new(0, "http://localhost:1234", "example.account");
     pub static ref SERVICE_ADDRESS: Address = Address::from_str("example.connector").unwrap();
     pub static ref MESSAGES_API: Matcher = Matcher::Regex(r"^/accounts/\d*/messages$".to_string());
     pub static ref SETTLEMENT_API: Matcher =

--- a/crates/interledger-store-redis/src/account.rs
+++ b/crates/interledger-store-redis/src/account.rs
@@ -11,10 +11,9 @@ use interledger_service_util::{
     MaxPacketAmountAccount, RateLimitAccount, RoundTripTimeAccount, DEFAULT_ROUND_TRIP_TIME,
 };
 use interledger_settlement::{SettlementAccount, SettlementEngineDetails};
-#[cfg(test)]
-use lazy_static::lazy_static;
 use log::error;
 use redis::{from_redis_value, ErrorKind, FromRedisValue, RedisError, ToRedisArgs, Value};
+
 use ring::aead;
 use serde::Serialize;
 use serde::Serializer;
@@ -23,8 +22,8 @@ use std::{
     convert::TryFrom,
     str::{self, FromStr},
 };
-use url::Url;
 
+use url::Url;
 const ACCOUNT_DETAILS_FIELDS: usize = 21;
 
 #[derive(Clone, Debug, Serialize)]
@@ -57,22 +56,6 @@ pub struct Account {
     #[serde(serialize_with = "optional_url_to_string")]
     pub(crate) settlement_engine_url: Option<Url>,
     pub(crate) settlement_engine_asset_scale: Option<u8>,
-    #[serde(serialize_with = "optional_address_to_string")]
-    pub(crate) settlement_engine_ilp_address: Option<Address>,
-}
-
-fn optional_address_to_string<S>(
-    address: &Option<Address>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    if let Some(address) = address {
-        serializer.serialize_str(str::from_utf8(address.as_ref()).unwrap_or(""))
-    } else {
-        serializer.serialize_none()
-    }
 }
 
 fn address_to_string<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error>
@@ -165,7 +148,6 @@ impl Account {
             amount_per_minute_limit: details.amount_per_minute_limit,
             settlement_engine_url,
             settlement_engine_asset_scale: details.settlement_engine_asset_scale,
-            settlement_engine_ilp_address: details.settlement_engine_ilp_address,
         })
     }
 
@@ -280,10 +262,6 @@ impl ToRedisArgs for AccountWithEncryptedTokens {
             "settlement_engine_asset_scale".write_redis_args(&mut rv);
             settlement_engine_asset_scale.write_redis_args(&mut rv);
         }
-        if let Some(ref settlement_engine_ilp_address) = account.settlement_engine_ilp_address {
-            "settlement_engine_ilp_address".write_redis_args(&mut rv);
-            rv.push(settlement_engine_ilp_address.to_bytes().to_vec());
-        }
 
         debug_assert!(rv.len() <= ACCOUNT_DETAILS_FIELDS * 2);
         debug_assert!((rv.len() % 2) == 0);
@@ -307,14 +285,7 @@ impl FromRedisValue for AccountWithEncryptedTokens {
         };
         let round_trip_time: Option<u64> = get_value_option("round_trip_time", &hash)?;
         let round_trip_time: u64 = round_trip_time.unwrap_or(DEFAULT_ROUND_TRIP_TIME);
-        let settlement_engine_ilp_address: Option<String> =
-            get_value_option("settlement_engine_ilp_address", &hash)?;
-        let settlement_engine_ilp_address =
-            if let Some(ref settlement_engine_ilp_address) = settlement_engine_ilp_address {
-                Address::from_str(settlement_engine_ilp_address).ok()
-            } else {
-                None
-            };
+
         Ok(AccountWithEncryptedTokens {
             account: Account {
                 id: get_value("id", &hash)?,
@@ -340,7 +311,6 @@ impl FromRedisValue for AccountWithEncryptedTokens {
                     "settlement_engine_asset_scale",
                     &hash,
                 )?,
-                settlement_engine_ilp_address,
             },
         })
     }
@@ -494,12 +464,10 @@ impl SettlementAccount for Account {
         match (
             &self.settlement_engine_url,
             self.settlement_engine_asset_scale,
-            &self.settlement_engine_ilp_address,
         ) {
-            (Some(url), Some(asset_scale), Some(ilp_address)) => Some(SettlementEngineDetails {
+            (Some(url), Some(asset_scale)) => Some(SettlementEngineDetails {
                 url: url.clone(),
                 asset_scale,
-                ilp_address: ilp_address.clone(),
             }),
             _ => None,
         }
@@ -509,6 +477,7 @@ impl SettlementAccount for Account {
 #[cfg(test)]
 mod redis_account {
     use super::*;
+    use lazy_static::lazy_static;
 
     lazy_static! {
         static ref ACCOUNT_DETAILS: AccountDetails = AccountDetails {
@@ -532,7 +501,6 @@ mod redis_account {
             packets_per_minute_limit: None,
             settlement_engine_asset_scale: None,
             settlement_engine_url: None,
-            settlement_engine_ilp_address: None,
         };
     }
 

--- a/crates/interledger-store-redis/tests/common/fixtures.rs
+++ b/crates/interledger-store-redis/tests/common/fixtures.rs
@@ -25,7 +25,6 @@ lazy_static! {
         packets_per_minute_limit: Some(2),
         settlement_engine_url: None,
         settlement_engine_asset_scale: None,
-        settlement_engine_ilp_address: None,
     };
     pub static ref ACCOUNT_DETAILS_1: AccountDetails = AccountDetails {
         ilp_address: Address::from_str("example.bob").unwrap(),
@@ -48,7 +47,6 @@ lazy_static! {
         packets_per_minute_limit: Some(20),
         settlement_engine_url: None,
         settlement_engine_asset_scale: None,
-        settlement_engine_ilp_address: None,
     };
     pub static ref ACCOUNT_DETAILS_2: AccountDetails = AccountDetails {
         ilp_address: Address::from_str("example.charlie").unwrap(),
@@ -71,6 +69,5 @@ lazy_static! {
         packets_per_minute_limit: None,
         settlement_engine_url: None,
         settlement_engine_asset_scale: None,
-        settlement_engine_ilp_address: None,
     };
 }

--- a/crates/interledger-store-redis/tests/routing_test.rs
+++ b/crates/interledger-store-redis/tests/routing_test.rs
@@ -54,7 +54,6 @@ fn polls_for_route_updates() {
                             packets_per_minute_limit: None,
                             settlement_engine_url: None,
                             settlement_engine_asset_scale: None,
-                            settlement_engine_ilp_address: None,
                         })
                     })
                     .and_then(move |_| {

--- a/crates/interledger/src/main.rs
+++ b/crates/interledger/src/main.rs
@@ -60,7 +60,6 @@ pub fn main() {
                             Arg::with_name("btp_server")
                                 .long("btp_server")
                                 .takes_value(true)
-                                .default_value(&moneyd_uri)
                                 .help("URI of a moneyd or BTP Server to pay from"),
                             Arg::with_name("http_server")
                                 .long("http_server")
@@ -338,7 +337,6 @@ pub fn main() {
                             .ok(),
                         settlement_engine_url: None,
                         settlement_engine_asset_scale: None,
-                        settlement_engine_ilp_address: None,
                     };
                     tokio::run(insert_account_redis(redis_uri, &server_secret, account));
                 }

--- a/crates/interledger/src/node.rs
+++ b/crates/interledger/src/node.rs
@@ -296,7 +296,7 @@ where
         })
 }
 
-fn generate_redis_secret(secret_seed: &[u8; 32]) -> [u8; 32] {
+pub fn generate_redis_secret(secret_seed: &[u8; 32]) -> [u8; 32] {
     let mut redis_secret: [u8; 32] = [0; 32];
     let sig = hmac::sign(
         &hmac::SigningKey::new(&digest::SHA256, secret_seed),

--- a/crates/interledger/tests/btp_end_to_end.rs
+++ b/crates/interledger/tests/btp_end_to_end.rs
@@ -57,7 +57,6 @@ fn btp_end_to_end() {
                     amount_per_minute_limit: None,
                     settlement_engine_url: None,
                     settlement_engine_asset_scale: None,
-                    settlement_engine_ilp_address: None,
                 }),
                 node.insert_account(AccountDetails {
                     ilp_address: Address::from_str("example.node.two").unwrap(),
@@ -80,7 +79,6 @@ fn btp_end_to_end() {
                     amount_per_minute_limit: None,
                     settlement_engine_url: None,
                     settlement_engine_asset_scale: None,
-                    settlement_engine_ilp_address: None,
                 }),
             ])
         });

--- a/crates/interledger/tests/three_nodes.rs
+++ b/crates/interledger/tests/three_nodes.rs
@@ -78,7 +78,6 @@ fn three_nodes() {
                 amount_per_minute_limit: None,
                 settlement_engine_url: None,
                 settlement_engine_asset_scale: None,
-                settlement_engine_ilp_address: None,
             })
             .and_then(move |_|
         // TODO insert the accounts via HTTP request
@@ -104,7 +103,6 @@ fn three_nodes() {
                 amount_per_minute_limit: None,
                 settlement_engine_url: None,
                 settlement_engine_asset_scale: None,
-                                settlement_engine_ilp_address: None,
             }))
             .and_then(move |_| node1.serve()),
     );
@@ -143,7 +141,6 @@ fn three_nodes() {
                 amount_per_minute_limit: None,
                 settlement_engine_url: None,
                 settlement_engine_asset_scale: None,
-                settlement_engine_ilp_address: None,
             }),
             node2.insert_account(AccountDetails {
                 ilp_address: Address::from_str("example.two.three").unwrap(),
@@ -166,7 +163,6 @@ fn three_nodes() {
                 amount_per_minute_limit: None,
                 settlement_engine_url: None,
                 settlement_engine_asset_scale: None,
-                settlement_engine_ilp_address: None,
             }),
         ])
         .and_then(move |_| node2.serve())
@@ -223,7 +219,6 @@ fn three_nodes() {
                     amount_per_minute_limit: None,
                     settlement_engine_url: None,
                     settlement_engine_asset_scale: None,
-                    settlement_engine_ilp_address: None,
                 }),
                 node3_clone.insert_account(AccountDetails {
                     ilp_address: Address::from_str("example.two").unwrap(),
@@ -246,7 +241,6 @@ fn three_nodes() {
                     amount_per_minute_limit: None,
                     settlement_engine_url: None,
                     settlement_engine_asset_scale: None,
-                    settlement_engine_ilp_address: None,
                 }),
             ])
             .and_then(move |_| node3.serve())

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,238 @@
+# Guide to E2E Testing Interledger settlement with the Ethereum Ledger
+
+First, you need an Ethereum network. We'll use
+[ganache-cli](https://github.com/trufflesuite/ganache-cli) which deploys a local
+Ethereum testnet at `localhost:8545`. You're free to use any other
+testnet/mainnet you want. To install `ganache-cli`, run 
+`npm install -g ganache-cli`. You also need to have `redis-server` and
+`redis-cli` available in your PATH. In Ubuntu, you can obtain these by running `sudo apt-get install redis-server`
+
+We will need **7** terminal windows in total to follow this tutorial in depth. You can run the
+provided `settlement_test.sh` script instead to see how the full process works.
+
+
+1. Ethereum Network (ganache-cli)
+2. Alice's
+    1. Connector
+    2. Settlement Engine
+    3. Redis Store
+2. Bob's
+    1. Connector
+    2. Settlement Engine
+    3. Redis Store
+
+For ease, you may want to set these environment variables to save you some
+typing:
+```
+ILP_DIR=<path to interledger-rs>
+ILP=$ILP_DIR/target/debug/interledger
+```
+
+## 1. Launch Ganache
+
+This will launch an Ethereum testnet with 10 prefunded accounts. The mnemonic is
+used because we want to know the keys we'll use for Alice and Bob (otherwise
+they are randomized)
+
+ganache-cli -m "abstract vacuum mammal awkward pudding scene penalty purchase
+dinner depart evoke puzzle" -i 1
+
+## 2. Configure Alice
+
+1. In a new terminal, execute `redis-server --port 6379` to launch Redis for
+   Alice.
+2. Set Alice's key and address:
+```bash
+ALICE_ADDRESS="3cdb3d9e1b74692bb1e3bb5fc81938151ca64b02"
+ALICE_KEY="380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc" 
+```
+3. Launch Alice's settlement engine in a new terminal by running:
+
+```bash
+RUST_LOG=interledger=debug $ILP settlement-engine ethereum-ledger \
+--key $ALICE_KEY \
+--server_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+--confirmations 0 \
+--poll_frequency 1 \
+--ethereum_endpoint http://127.0.0.1:8545 \
+--connector_url http://127.0.0.1:7771 \
+--redis_uri redis://127.0.0.1:6379 \
+--watch_incoming true \
+--port 3000
+```
+
+4. Configure Alice's connector by putting the following data inside a config
+   file, let's call that `alice.yml`. 
+
+```yaml 
+ilp_address: "example.alice"
+secret_seed: "8852500887504328225458511465394229327394647958135038836332350604"
+admin_auth_token: "hi_alice" 
+redis_connection: "redis://127.0.0.1:6379"
+settlement_address: "127.0.0.1:7771" 
+http_address: "127.0.0.1:7770"
+btp_address: "127.0.0.1:7768" 
+default_spsp_account: "0" 
+``` 
+
+5. Launch Alice's connector in a new terminal by running:
+
+```bash
+RUST_LOG="interledger=debug,interledger=trace" $ILP node --config alice.yml
+```
+
+6. Insert Alice's account into her connector. 
+
+The parameters are:
+ILP Address: `example.alice`
+Asset Code: `ETH`
+Asset Scale: `18`
+Max Packet Amount: `10`
+Http Endpoint: `http://localhost:7770/ilp` (ilp over HTTP)
+HTTP Incoming Token: `in_alice`
+HTTP Outgoing Token: `out_alice`
+Settle To: `10`
+
+```bash
+curl http://localhost:7770/accounts -X POST \
+     -d "ilp_address=example.alice&asset_code=ETH&asset_scale=18&max_packet_amount=10&http_endpoint=http://127.0.0.1:7770/ilp&http_incoming_token=in_alice&outgoing_token=out_alice&settle_to=-10" \
+     -H "Authorization: Bearer hi_alice"
+```
+
+All set! Now Alice has her connector, settlement engine and redis store up and
+running.
+
+## 3. Configure Bob
+
+1. In a new terminal, execute `redis-server --port 6380` to launch Redis for
+   Bob.
+2. Set Bob's key and address:
+```bash
+BOB_ADDRESS="9b925641c5ef3fd86f63bff2da55a0deeafd1263"
+BOB_KEY="cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e"
+```
+3. Launch Bob's settlement engine in a new terminal by running:
+
+```bash
+RUST_LOG=interledger=debug $ILP settlement-engine ethereum-ledger \
+--key $BOB_KEY \
+--server_secret bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+--confirmations 0 \
+--poll_frequency 1 \
+--ethereum_endpoint http://127.0.0.1:8545 \
+--connector_url http://127.0.0.1:8771 \
+--redis_uri redis://127.0.0.1:6380 \
+--watch_incoming true \
+--port 3001
+```
+
+4. Configure Bob's connector by putting the following data inside a config
+   file, let's call that `bob.yml`. 
+
+```yaml 
+ilp_address: "example.bob"
+secret_seed: "1604966725982139900555208458637022875563691455429373719368053354"
+admin_auth_token: "hi_bob"
+redis_connection: "redis://127.0.0.1:6380"
+settlement_address: "127.0.0.1:8771"
+http_address: "127.0.0.1:8770"
+btp_address: "127.0.0.1:8768"
+default_spsp_account: "0"
+``` 
+
+5. Launch Bob's connector in a new terminal by running:
+
+```bash
+RUST_LOG="interledger=debug,interledger=trace" $ILP node --config bob.yml
+```
+
+6. Insert Bob's account into his connector. 
+
+The parameters are:
+ILP Address: `example.bob`
+Asset Code: `ETH`
+Asset Scale: `18`
+Max Packet Amount: `10`
+Http Endpoint: `http://localhost:8770/ilp` (ilp over HTTP)
+HTTP Incoming Token: `in_bob`
+HTTP Outgoing Token: `out_bob`
+Settle To: `10`
+
+```bash
+curl http://localhost:8770/accounts -X POST \
+     -d "ilp_address=example.bob&asset_code=ETH&asset_scale=18&max_packet_amount=10&http_endpoint=http://127.0.0.1:8770/ilp&http_incoming_token=in_bob&outgoing_token=out_bob&settle_to=-10" \
+     -H "Authorization: Bearer hi_bob"
+```
+
+Now we have both Alice and Bob up and running.
+
+## 4. Peer each other.
+
+### Insert Bob's account to Alice's connector
+```bash
+curl http://localhost:7770/accounts -X POST \
+    -d "ilp_address=example.bob&asset_code=ETH&asset_scale=18&max_packet_amount=10&settlement_engine_url=http://127.0.0.1:3000&settlement_engine_asset_scale=18&http_endpoint=http://127.0.0.1:8770/ilp&http_incoming_token=bob&http_outgoing_token=alice&settle_threshold=70&min_balance=-100&settle_to=10" \
+    -H "Authorization: Bearer hi_alice
+```
+
+Notice how we use Alice's settlement engine endpoint while registering Bob. This
+means that whenever Alice interacts with Bob's account, she'll use that
+Settlement Engine.
+
+`settle_threshold`, `min_balance` and `settle_to` are parameters related to how
+often settlement is made, which is tracked in [issue 121](https://github.com/emschwartz/interledger-rs/issues/121).
+
+### Insert Alice's account to Bob's connector
+
+```bash
+curl http://localhost:8770/accounts -X POST \
+     -d "ilp_address=example.alice&asset_code=ETH&asset_scale=18&max_packet_amount=10&settlement_engine_url=http://127.0.0.1:3001&settlement_engine_asset_scale=18&http_endpoint=http://127.0.0.1:7770/ilp&http_incoming_token=alice&http_outgoing_token=bob&settle_threshold=70&min_balance=-100&settle_to=-10" \
+     -H "Authorization: Bearer hi_bob"
+```
+
+## 5. Verify that addresses have been exchanged
+
+Bob's address in Alice's store: `redis-cli -p 6379 hgetall "settlement:ledger:eth:1"`
+Alice's address in Bob's store: `redis-cli -p 6380 hgetall "settlement:ledger:eth:1"`
+
+## 6. Make some payments!
+
+A `pay_dump.sh` script is provided which you can use to make [SPSP
+payments](https://interledger.org/rfcs/0009-simple-payment-setup-protocol/)
+between the two. After making an SPSP payment, it subsequently dumps the state
+of the balance/prepaid_amount of each store, so that you can get a sense of what
+is happening under the hood after each payment. You can also monitor your
+connector and settlement engine's logs.
+
+Alice pays Bob:
+```bash
+curl localhost:7770/pay \
+        -d "{ \"receiver\" : \"http://localhost:8770\", \"source_amount\": 5  }" \
+        -H "Authorization: Bearer in_alice" -H "Content-Type: application/json"
+```
+
+Bob pays Alice:
+```bash
+curl localhost:8770/pay \
+        -d "{ \"receiver\" : \"http://localhost:7770\", \"source_amount\": 7  }" \
+        -H "Authorization: Bearer in_bob" -H "Content-Type: application/json"
+```
+
+The net after this should be that Alice's store shows positive 2 balance on her
+account (`accounts:0`), and negative 2 for Bob. Bob's store should show the
+opposite:
+
+```bash
+echo "Alice:Alice $(redis-cli hmget accounts:0 balance prepaid_amount)"
+echo "Alice:Bob $(redis-cli hmget accounts:1 balance prepaid_amount)"
+
+echo "Bob:Bob $(redis-cli -p 6380 hmget accounts:0 balance prepaid_amount)"
+echo "Bib:Alice $(redis-cli -p 6380 hmget accounts:1 balance prepaid_amount)"
+```
+
+
+If you inspect ganache-cli's output, you will notice that the block number has
+increased as a result of the settlement executions.
+
+Done! Full E2E test between 2 users over SPSP utilizing the new settlement
+architecture in an Ethereum Ledger settlement engine.

--- a/examples/alice.yaml
+++ b/examples/alice.yaml
@@ -1,0 +1,8 @@
+ilp_address: "example.alice"
+secret_seed: "8852500887504328225458511465394229327394647958135038836332350604"
+admin_auth_token: "hi_alice"
+redis_connection: "redis://127.0.0.1:6379"
+settlement_address: "127.0.0.1:7771"
+http_address: "127.0.0.1:7770"
+btp_address: "127.0.0.1:7768"
+default_spsp_account: "0"

--- a/examples/bob.yaml
+++ b/examples/bob.yaml
@@ -1,0 +1,8 @@
+ilp_address: "example.bob"
+secret_seed: "1604966725982139900555208458637022875563691455429373719368053354"
+admin_auth_token: "hi_bob"
+redis_connection: "redis://127.0.0.1:6380"
+settlement_address: "127.0.0.1:8771"
+http_address: "127.0.0.1:8770"
+btp_address: "127.0.0.1:8768"
+default_spsp_account: "0"

--- a/examples/init.sh
+++ b/examples/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Starts 2 redis instances at ports 6379 and 6380 for testing
+# Kills whatever's already running at 6379 and 6380
+
+if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
+    redis-cli -p 6379 shutdown
+fi
+redis-server --port 6379 --daemonize yes &> logs/redis-6379.log 
+
+if lsof -Pi :6380 -sTCP:LISTEN -t >/dev/null ; then
+    redis-cli -p 6380 shutdown
+fi
+redis-server --port 6380 --daemonize yes &> logs/redis-6380.log 

--- a/examples/pay_dump.sh
+++ b/examples/pay_dump.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# who do we send to?
+if [[ $1 == bob ]]
+then
+    PORT=7770
+    RECEIVER=8770
+    AUTH=in_alice
+else
+    PORT=8770
+    RECEIVER=7770
+    AUTH=in_bob
+fi
+
+if [ ! -z "$2"  ]
+then
+    set -x
+    curl localhost:$PORT/pay \
+        -d "{ \"receiver\" : \"http://localhost:$RECEIVER\", \"source_amount\": $2  }" \
+        -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json"
+    set +x
+fi
+
+printf "\n----\n"
+
+echo "Bob's balance on Alice's store"
+curl localhost:7770/accounts/1/balance -H "Authorization: Bearer bob"
+
+printf "\n----\n"
+
+echo "Alice's balance on Bob's store"
+curl localhost:8770/accounts/1/balance -H "Authorization: Bearer alice"
+
+printf "\n----\n"
+
+# dump the settlement transactions
+geth --exec "eth.getTransaction(eth.getBlock(eth.blockNumber-1).transactions[0])" attach http://localhost:8545
+geth --exec "eth.getTransaction(eth.getBlock(eth.blockNumber).transactions[0])" attach http://localhost:8545

--- a/examples/settlements_test.sh
+++ b/examples/settlements_test.sh
@@ -1,0 +1,113 @@
+killall interledger interledger-settlement-engines node
+
+# start ganache
+ganache-cli -m "abstract vacuum mammal awkward pudding scene penalty purchase dinner depart evoke puzzle" -i 1 &> /dev/null &
+
+sleep 3 # wait for ganache to start
+
+ROOT=$HOME/projects/xpring-contract
+ILP_DIR=$ROOT/interledger-rs
+ILP=$ILP_DIR/target/debug/interledger
+ILP_ENGINE=$ILP_DIR/target/debug/interledger-settlement-engines
+CONFIGS=$ILP_DIR/examples
+
+
+LOGS=`pwd`/settlement_test_logs
+rm -rf $LOGS && mkdir -p $LOGS
+
+echo "Initializing redis"
+bash $ILP_DIR/examples/init.sh &
+redis-cli -p 6379 flushall
+redis-cli -p 6380 flushall
+
+sleep 1
+
+ALICE_ADDRESS="3cdb3d9e1b74692bb1e3bb5fc81938151ca64b02"
+ALICE_KEY="380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
+BOB_ADDRESS="9b925641c5ef3fd86f63bff2da55a0deeafd1263"
+BOB_KEY="cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e"
+
+
+echo "Initializing Alice SE"
+RUST_LOG=interledger=debug $ILP_ENGINE ethereum-ledger \
+--key $ALICE_KEY \
+--server_secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+--confirmations 0 \
+--poll_frequency 1000 \
+--ethereum_endpoint http://127.0.0.1:8545 \
+--connector_url http://127.0.0.1:7771 \
+--redis_uri redis://127.0.0.1:6379 \
+--watch_incoming true \
+--port 3000 &> $LOGS/engine_alice.log &
+
+echo "Initializing Bob SE"
+RUST_LOG=interledger=debug $ILP_ENGINE ethereum-ledger \
+--key $BOB_KEY \
+--server_secret bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+--confirmations 0 \
+--poll_frequency 1000 \
+--ethereum_endpoint http://127.0.0.1:8545 \
+--connector_url http://127.0.0.1:8771 \
+--redis_uri redis://127.0.0.1:6380 \
+--watch_incoming true \
+--port 3001 &> $LOGS/engine_bob.log &
+
+sleep 1
+
+echo "Initializing Alice Connector"
+RUST_LOG="interledger=debug,interledger=trace" $ILP node --config $CONFIGS/alice.yaml &> $LOGS/ilp_alice.log &
+echo "Initializing Bob Connector"
+RUST_LOG="interledger=debug,interledger=trace" $ILP node --config $CONFIGS/bob.yaml &> $LOGS/ilp_bob.log &
+
+sleep 2
+read -p "Press [Enter] key to continue..."
+
+# insert alice's account details on Alice's connector
+printf "\nInitializing Alice's account on her connector\n"
+curl http://localhost:7770/accounts -X POST \
+    -d "ilp_address=example.alice&asset_code=ETH&asset_scale=18&max_packet_amount=10&http_endpoint=http://127.0.0.1:7770/ilp&http_incoming_token=in_alice&outgoing_token=out_alice&settle_to=-10" \
+    -H "Authorization: Bearer hi_alice"
+
+printf "\n---------------------------------------\n"
+
+# insert Bob's account details on Alice's connector
+echo "Initializing Bob's account on Alice's connector (this will not return until Bob adds Alice in his connector)"
+curl http://localhost:7770/accounts -X POST \
+    -d "ilp_address=example.bob&asset_code=ETH&asset_scale=18&max_packet_amount=10&settlement_engine_url=http://127.0.0.1:3000&settlement_engine_asset_scale=18&http_endpoint=http://127.0.0.1:8770/ilp&http_incoming_token=bob&http_outgoing_token=alice&settle_threshold=70&min_balance=-100&settle_to=10" \
+    -H "Authorization: Bearer hi_alice" &
+
+printf "\n---------------------------------------\n"
+read -p "Press [Enter] key to continue..."
+
+# insert bob's account on bob's conncetor
+printf "\nInitializing Bob's account on his connector\n"
+curl http://localhost:8770/accounts -X POST \
+    -d "ilp_address=example.bob&asset_code=ETH&asset_scale=18&max_packet_amount=10&http_endpoint=http://127.0.0.1:7770/ilp&http_incoming_token=in_bob&outgoing_token=out_bob&settle_to=-10" \
+    -H "Authorization: Bearer hi_bob"
+
+printf "\n---------------------------------------\n"
+read -p "Press [Enter] key to continue..."
+ 
+# insert Alice's account details on Bob's connector
+# when setting up an account with another party makes senes to give them some slack if they do not prefund
+echo "Initializing Alice's account on Bob's connector"
+curl http://localhost:8770/accounts -X POST \
+     -d "ilp_address=example.alice&asset_code=ETH&asset_scale=18&max_packet_amount=10&settlement_engine_url=http://127.0.0.1:3001&settlement_engine_asset_scale=18&http_endpoint=http://127.0.0.1:7770/ilp&http_incoming_token=alice&http_outgoing_token=bob&settle_threshold=70&min_balance=-100&settle_to=-10" \
+     -H "Authorization: Bearer hi_bob" &
+
+sleep 2
+printf "\n---------------------------------------\n"
+read -p "Press [Enter] key to continue..."
+
+# Their settlement engines should be configured automatically 
+echo "Alice Connector Store:"
+redis-cli -p 6379 hgetall "accounts:1"
+echo "Alice Engine Store:"
+redis-cli -p 6379 hgetall "eth:ledger:settlement:1"
+
+printf "\n---------------------------------------\n"
+
+echo "Bob Connector Store:"
+redis-cli -p 6380 hgetall "accounts:1"
+echo "Bob Engine Store:"
+redis-cli -p 6380 hgetall "eth:ledger:settlement:1"


### PR DESCRIPTION
This PR defines a `SettlementEngine` trait and a tower-web service which exposes the endpoints from [RFC536](https://github.com/interledger/rfcs/pull/536/files) and the [forum thread](https://forum.interledger.org/t/settlement-architecture/545). New engines must be implemented under the `engines` directory.

It also defines an Ethereum engine which makes settlements with onchain transactions, and notifies the connector once the onchain transaction has sufficient confirmations (adjustable param). You can run the engine by building and then: 

`./target/debug/interledger settlement-engine ethereum-ledger --key YOUR_ETH_PRIVATE_KEY --server_secret YOUR_REDIS_SECRET --confirmations NUM_CONFS`

Notes: 
- Due to certain version mismatches between the published `ethereum_types` and `primitive_types` in https://github.com/synlestidae/ethereum-tx-sign/ and rust-web3, it was forked to use web3 0.6 and re-export it https://github.com/gakonst/ethereum-tx-sign/commit/bfd289e2ea1394795856d78b6375e5bc041607a4 