### PR TITLE
Remove all `extern crate` except for tower-web

### DIFF
--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -1,10 +1,6 @@
 #![recursion_limit = "128"]
 #[macro_use]
 extern crate tower_web;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_json;
 
 use bytes::Bytes;
 use futures::Future;
@@ -17,7 +13,7 @@ use interledger_service_util::{BalanceStore, ExchangeRateStore};
 use interledger_settlement::{SettlementAccount, SettlementStore};
 use serde::Serialize;
 use std::str;
-use tower_web::{net::ConnectionStream, ServiceBuilder};
+use tower_web::{net::ConnectionStream, Extract, Response, ServiceBuilder};
 
 mod routes;
 use self::routes::*;

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -7,9 +7,11 @@ use hyper::Response;
 use interledger_http::{HttpAccount, HttpStore};
 use interledger_service::Account;
 use interledger_service_util::BalanceStore;
+use log::{debug, error};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::str::FromStr;
+use tower_web::{impl_web, Response};
 
 #[derive(Serialize, Response, Debug)]
 #[web(status = "200")]

--- a/crates/interledger-api/src/routes/ilp.rs
+++ b/crates/interledger-api/src/routes/ilp.rs
@@ -2,6 +2,7 @@ use futures::Future;
 use hyper::{Body, Error, Request, Response};
 use interledger_http::{HttpServerService, HttpStore};
 use interledger_service::IncomingService;
+use tower_web::impl_web;
 
 pub struct IlpApi<S, T> {
     http_server_service: HttpServerService<S, T>,

--- a/crates/interledger-api/src/routes/settings.rs
+++ b/crates/interledger-api/src/routes/settings.rs
@@ -7,6 +7,7 @@ use hyper::Response;
 use interledger_router::RouterStore;
 use interledger_service::Account;
 use interledger_service_util::ExchangeRateStore;
+use log::{debug, error};
 use std::{
     collections::HashMap,
     iter::FromIterator,

--- a/crates/interledger-api/src/routes/spsp.rs
+++ b/crates/interledger-api/src/routes/spsp.rs
@@ -9,7 +9,10 @@ use interledger_http::{HttpAccount, HttpStore};
 use interledger_ildcp::IldcpAccount;
 use interledger_service::{AccountStore, IncomingService};
 use interledger_spsp::{pay, SpspResponder};
+use log::{debug, error};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use tower_web::{impl_web, Extract, Response};
 
 #[derive(Extract, Debug)]
 struct SpspPayRequest {

--- a/crates/interledger-btp/src/client.rs
+++ b/crates/interledger-btp/src/client.rs
@@ -3,6 +3,7 @@ use super::service::BtpOutgoingService;
 use super::BtpAccount;
 use futures::{future::join_all, Future, Sink};
 use interledger_service::*;
+use log::{debug, error, trace};
 use rand::random;
 use std::iter::IntoIterator;
 use tokio_tungstenite::connect_async;

--- a/crates/interledger-btp/src/errors.rs
+++ b/crates/interledger-btp/src/errors.rs
@@ -1,4 +1,5 @@
 use chrono;
+use quick_error::quick_error;
 use std;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;

--- a/crates/interledger-btp/src/lib.rs
+++ b/crates/interledger-btp/src/lib.rs
@@ -6,14 +6,6 @@
 //! Because this protocol uses WebSockets, only one party needs to have a publicly-accessible HTTPS
 //! endpoint but both sides can send and receive ILP packets.
 
-#[macro_use]
-extern crate quick_error;
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-
 use futures::Future;
 use interledger_service::Account;
 use url::Url;

--- a/crates/interledger-btp/src/packet.rs
+++ b/crates/interledger-btp/src/packet.rs
@@ -3,6 +3,8 @@ use super::oer::{MutBufOerExt, ReadOerExt};
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::BufMut;
 use chrono::{DateTime, TimeZone, Utc};
+#[cfg(test)]
+use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use std::io::prelude::*;
 use std::io::Cursor;

--- a/crates/interledger-btp/src/server.rs
+++ b/crates/interledger-btp/src/server.rs
@@ -5,6 +5,7 @@ use base64;
 use futures::{future::result, Future, Sink, Stream};
 use interledger_ildcp::IldcpResponse;
 use interledger_service::*;
+use log::{debug, error, warn};
 use ring::digest::{digest, SHA256};
 use std::{net::SocketAddr, str};
 use tokio_executor::spawn;

--- a/crates/interledger-btp/src/service.rs
+++ b/crates/interledger-btp/src/service.rs
@@ -9,6 +9,7 @@ use futures::{
 use hashbrown::HashMap;
 use interledger_packet::{ErrorCode, Fulfill, Packet, Prepare, Reject, RejectBuilder};
 use interledger_service::*;
+use log::{debug, error, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use rand::random;
 use std::{

--- a/crates/interledger-ccp/src/fixtures.rs
+++ b/crates/interledger-ccp/src/fixtures.rs
@@ -3,6 +3,8 @@ use crate::packet::*;
 use bytes::Bytes;
 use hex;
 use interledger_packet::Address;
+#[cfg(test)]
+use lazy_static::lazy_static;
 use std::str::FromStr;
 
 lazy_static! {

--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -9,11 +9,6 @@
 //! updates are used by the `Router` to forward incoming packets to the best next hop
 //! we know about.
 
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate lazy_static;
-
 use bytes::Bytes;
 use futures::Future;
 use hashbrown::HashMap;

--- a/crates/interledger-ccp/src/packet.rs
+++ b/crates/interledger-ccp/src/packet.rs
@@ -5,6 +5,8 @@ use interledger_packet::{
     oer::{BufOerExt, MutBufOerExt},
     Address, Fulfill, FulfillBuilder, ParseError, Prepare, PrepareBuilder,
 };
+use lazy_static::lazy_static;
+use log::error;
 use std::{
     convert::TryFrom,
     io::Read,

--- a/crates/interledger-ccp/src/routing_table.rs
+++ b/crates/interledger-ccp/src/routing_table.rs
@@ -2,6 +2,8 @@ use crate::packet::{Route, RouteUpdateRequest};
 use bytes::Bytes;
 use hashbrown::HashMap;
 use hex;
+use lazy_static::lazy_static;
+use log::{debug, trace};
 use ring::rand::{SecureRandom, SystemRandom};
 use std::iter::FromIterator;
 

--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -9,6 +9,9 @@ use interledger_packet::*;
 use interledger_service::{
     Account, BoxedIlpFuture, IncomingRequest, IncomingService, OutgoingRequest, OutgoingService,
 };
+#[cfg(test)]
+use lazy_static::lazy_static;
+use log::{debug, error, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use ring::digest::{digest, SHA256};
 use std::{

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -12,6 +12,8 @@ use interledger_service::{
     incoming_service_fn, outgoing_service_fn, BoxedIlpFuture, IncomingService, OutgoingRequest,
     OutgoingService,
 };
+#[cfg(test)]
+use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use std::str::FromStr;
 use std::{iter::FromIterator, sync::Arc};

--- a/crates/interledger-http/src/client.rs
+++ b/crates/interledger-http/src/client.rs
@@ -3,6 +3,7 @@ use bytes::BytesMut;
 use futures::{future::result, Future, Stream};
 use interledger_packet::{ErrorCode, Fulfill, Packet, Reject, RejectBuilder};
 use interledger_service::*;
+use log::{error, trace};
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
     r#async::{Chunk, Client, ClientBuilder, Response as HttpResponse},

--- a/crates/interledger-http/src/lib.rs
+++ b/crates/interledger-http/src/lib.rs
@@ -3,9 +3,6 @@
 //! Client and server implementations of the [ILP-Over-HTTP](https://github.com/interledger/rfcs/blob/master/0035-ilp-over-http/0035-ilp-over-http.md) bilateral communication protocol.
 //! This protocol is intended primarily for server-to-server communication between peers on the Interledger network.
 
-#[macro_use]
-extern crate log;
-
 use futures::Future;
 use interledger_service::Account;
 use url::Url;

--- a/crates/interledger-http/src/server.rs
+++ b/crates/interledger-http/src/server.rs
@@ -10,6 +10,7 @@ use hyper::{
 };
 use interledger_packet::{Fulfill, Prepare, Reject};
 use interledger_service::*;
+use log::{debug, error, trace};
 use std::convert::TryFrom;
 
 /// Max message size that is allowed to transfer from a request or a message.

--- a/crates/interledger-ildcp/src/client.rs
+++ b/crates/interledger-ildcp/src/client.rs
@@ -1,6 +1,7 @@
 use super::packet::*;
 use futures::Future;
 use interledger_service::*;
+use log::{debug, error};
 use std::convert::TryFrom;
 
 /// Get the ILP address and asset details for a given account.

--- a/crates/interledger-ildcp/src/lib.rs
+++ b/crates/interledger-ildcp/src/lib.rs
@@ -4,11 +4,6 @@
 //!
 //! This is used by clients to query for their ILP address and asset details such as asset code and scale.
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-
 use interledger_packet::Address;
 use interledger_service::Account;
 

--- a/crates/interledger-ildcp/src/packet.rs
+++ b/crates/interledger-ildcp/src/packet.rs
@@ -4,6 +4,7 @@ use interledger_packet::{
     oer::{predict_var_octet_string, BufOerExt, MutBufOerExt},
     Address, Fulfill, FulfillBuilder, ParseError, Prepare, PrepareBuilder,
 };
+use lazy_static::lazy_static;
 use std::{
     convert::TryFrom,
     fmt, str,

--- a/crates/interledger-ildcp/src/server.rs
+++ b/crates/interledger-ildcp/src/server.rs
@@ -3,6 +3,7 @@ use super::IldcpAccount;
 use futures::future::ok;
 use interledger_packet::*;
 use interledger_service::*;
+use log::debug;
 use std::marker::PhantomData;
 
 /// A simple service that intercepts incoming ILDCP requests

--- a/crates/interledger-router/src/lib.rs
+++ b/crates/interledger-router/src/lib.rs
@@ -12,9 +12,6 @@
 //! store can either be configured or populated using the `CcpRouteManager`
 //! (see the `interledger-ccp` crate for more details).
 
-#[macro_use]
-extern crate log;
-
 use bytes::Bytes;
 use hashbrown::HashMap;
 use interledger_service::{Account, AccountStore};

--- a/crates/interledger-router/src/router.rs
+++ b/crates/interledger-router/src/router.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 use futures::{future::err, Future};
 use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::*;
+use log::{error, trace};
 use std::str;
 
 /// # Interledger Router

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 use interledger_packet::{Address, ErrorCode, Fulfill, Reject, RejectBuilder};
 use interledger_service::*;
+use log::{debug, error};
 use std::marker::PhantomData;
 use tokio_executor::spawn;
 

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -3,6 +3,7 @@ use futures::{future::err, Future};
 use interledger_ildcp::IldcpAccount;
 use interledger_packet::{Address, ErrorCode, Fulfill, Reject, RejectBuilder};
 use interledger_service::*;
+use log::{error, trace};
 use std::marker::PhantomData;
 
 pub trait ExchangeRateStore {

--- a/crates/interledger-service-util/src/lib.rs
+++ b/crates/interledger-service-util/src/lib.rs
@@ -2,9 +2,6 @@
 //!
 //! Miscellaneous, small Interledger Services.
 
-#[macro_use]
-extern crate log;
-
 mod balance_service;
 mod echo_service;
 mod exchange_rates_service;

--- a/crates/interledger-service-util/src/rate_limit_service.rs
+++ b/crates/interledger-service-util/src/rate_limit_service.rs
@@ -4,6 +4,7 @@ use futures::{
 };
 use interledger_packet::{Address, ErrorCode, RejectBuilder};
 use interledger_service::{Account, BoxedIlpFuture, IncomingRequest, IncomingService};
+use log::{error, warn};
 use std::marker::PhantomData;
 
 pub trait RateLimitAccount: Account {

--- a/crates/interledger-service-util/src/validator_service.rs
+++ b/crates/interledger-service-util/src/validator_service.rs
@@ -2,6 +2,7 @@ use futures::{future::err, Future};
 use hex;
 use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::*;
+use log::error;
 use ring::digest::{digest, SHA256};
 use std::marker::PhantomData;
 use std::time::{Duration, SystemTime};

--- a/crates/interledger-settlement/src/api.rs
+++ b/crates/interledger-settlement/src/api.rs
@@ -9,6 +9,7 @@ use interledger_ildcp::IldcpAccount;
 use interledger_packet::PrepareBuilder;
 use interledger_service::{AccountStore, OutgoingRequest, OutgoingService};
 use interledger_service_util::{Convert, ConvertDetails};
+use log::error;
 use ring::digest::{digest, SHA256};
 use std::{
     marker::PhantomData,

--- a/crates/interledger-settlement/src/client.rs
+++ b/crates/interledger-settlement/src/client.rs
@@ -5,6 +5,7 @@ use futures::{
 };
 use interledger_ildcp::IldcpAccount;
 use interledger_service_util::{Convert, ConvertDetails};
+use log::{error, trace};
 use reqwest::r#async::Client;
 use uuid::Uuid;
 

--- a/crates/interledger-settlement/src/fixtures.rs
+++ b/crates/interledger-settlement/src/fixtures.rs
@@ -1,4 +1,6 @@
 use interledger_packet::Address;
+#[cfg(test)]
+use lazy_static::lazy_static;
 use mockito::Matcher;
 use std::str::FromStr;
 

--- a/crates/interledger-settlement/src/lib.rs
+++ b/crates/interledger-settlement/src/lib.rs
@@ -1,12 +1,7 @@
 #![recursion_limit = "128"]
 
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate tower_web;
-#[macro_use]
-#[cfg(test)]
-extern crate lazy_static;
 
 use bytes::Bytes;
 use futures::Future;

--- a/crates/interledger-settlement/src/message_service.rs
+++ b/crates/interledger-settlement/src/message_service.rs
@@ -5,6 +5,7 @@ use futures::{
 };
 use interledger_packet::{Address, ErrorCode, FulfillBuilder, RejectBuilder};
 use interledger_service::{BoxedIlpFuture, IncomingRequest, IncomingService};
+use log::error;
 use reqwest::r#async::Client;
 use std::marker::PhantomData;
 

--- a/crates/interledger-spsp/src/client.rs
+++ b/crates/interledger-spsp/src/client.rs
@@ -3,6 +3,7 @@ use futures::{future::result, Future};
 use interledger_packet::Address;
 use interledger_service::{Account, IncomingService};
 use interledger_stream::send_money;
+use log::{debug, error, trace};
 use reqwest::r#async::Client;
 use std::convert::TryFrom;
 

--- a/crates/interledger-spsp/src/lib.rs
+++ b/crates/interledger-spsp/src/lib.rs
@@ -5,15 +5,10 @@
 //! This uses a simple HTTPS request to establish a shared key between the sender and receiver that is used to
 //! authenticate ILP packets sent between them. SPSP uses the STREAM transport protocol for sending money and data over ILP.
 
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate failure;
-
+use failure::Fail;
 use interledger_packet::Address;
 use interledger_stream::Error as StreamError;
+use serde::{Deserialize, Serialize};
 
 mod client;
 mod server;

--- a/crates/interledger-spsp/src/server.rs
+++ b/crates/interledger-spsp/src/server.rs
@@ -4,6 +4,7 @@ use futures::future::{ok, FutureResult, IntoFuture};
 use hyper::{service::Service as HttpService, Body, Error, Request, Response};
 use interledger_packet::Address;
 use interledger_stream::ConnectionGenerator;
+use log::debug;
 use std::error::Error as StdError;
 use std::{fmt, str};
 

--- a/crates/interledger-store-redis/src/account.rs
+++ b/crates/interledger-store-redis/src/account.rs
@@ -11,8 +11,12 @@ use interledger_service_util::{
     MaxPacketAmountAccount, RateLimitAccount, RoundTripTimeAccount, DEFAULT_ROUND_TRIP_TIME,
 };
 use interledger_settlement::{SettlementAccount, SettlementEngineDetails};
+#[cfg(test)]
+use lazy_static::lazy_static;
+use log::error;
 use redis::{from_redis_value, ErrorKind, FromRedisValue, RedisError, ToRedisArgs, Value};
 use ring::aead;
+use serde::Serialize;
 use serde::Serializer;
 use std::{
     collections::HashMap,

--- a/crates/interledger-store-redis/src/crypto.rs
+++ b/crates/interledger-store-redis/src/crypto.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use log::error;
 use ring::{
     aead, digest, hmac,
     rand::{SecureRandom, SystemRandom},

--- a/crates/interledger-store-redis/src/lib.rs
+++ b/crates/interledger-store-redis/src/lib.rs
@@ -1,13 +1,6 @@
 //! # interledger-store-redis
 //!
 //! A Store that uses [Redis](https://redis.io/) as the database for storing account details, balances, the routing table, etc.
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde;
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
 
 mod account;
 mod crypto;

--- a/crates/interledger-store-redis/src/store.rs
+++ b/crates/interledger-store-redis/src/store.rs
@@ -6,6 +6,7 @@ use futures::{
     Future, Stream,
 };
 use hashbrown::{HashMap, HashSet};
+use log::{debug, error, trace, warn};
 
 use http::StatusCode;
 use interledger_api::{AccountDetails, NodeStore};

--- a/crates/interledger-store-redis/tests/accounts_test.rs
+++ b/crates/interledger-store-redis/tests/accounts_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use common::*;

--- a/crates/interledger-store-redis/tests/balances_test.rs
+++ b/crates/interledger-store-redis/tests/balances_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use common::*;

--- a/crates/interledger-store-redis/tests/btp_test.rs
+++ b/crates/interledger-store-redis/tests/btp_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use common::*;

--- a/crates/interledger-store-redis/tests/common/fixtures.rs
+++ b/crates/interledger-store-redis/tests/common/fixtures.rs
@@ -1,5 +1,6 @@
 use interledger_api::AccountDetails;
 use interledger_packet::Address;
+use lazy_static::lazy_static;
 use std::str::FromStr;
 
 lazy_static! {

--- a/crates/interledger-store-redis/tests/common/redis_helpers.rs
+++ b/crates/interledger-store-redis/tests/common/redis_helpers.rs
@@ -1,11 +1,6 @@
 // Copied from https://github.com/mitsuhiko/redis-rs/blob/9a1777e8a90c82c315a481cdf66beb7d69e681a2/tests/support/mod.rs
 #![allow(dead_code)]
 
-extern crate futures;
-extern crate net2;
-extern crate os_type;
-extern crate rand;
-
 use redis;
 
 use std::env;
@@ -16,7 +11,7 @@ use std::time::Duration;
 
 use std::path::PathBuf;
 
-use self::futures::Future;
+use futures::Future;
 
 use redis::RedisError;
 

--- a/crates/interledger-store-redis/tests/common/store_helpers.rs
+++ b/crates/interledger-store-redis/tests/common/store_helpers.rs
@@ -4,6 +4,7 @@ use env_logger;
 use futures::Future;
 use interledger_api::NodeStore;
 use interledger_store_redis::{RedisStore, RedisStoreBuilder};
+use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use tokio::runtime::Runtime;
 

--- a/crates/interledger-store-redis/tests/http_test.rs
+++ b/crates/interledger-store-redis/tests/http_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use common::*;

--- a/crates/interledger-store-redis/tests/rate_limiting_test.rs
+++ b/crates/interledger-store-redis/tests/rate_limiting_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 use common::*;
 use futures::future::join_all;

--- a/crates/interledger-store-redis/tests/rates_test.rs
+++ b/crates/interledger-store-redis/tests/rates_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use common::*;

--- a/crates/interledger-store-redis/tests/routing_test.rs
+++ b/crates/interledger-store-redis/tests/routing_test.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use bytes::Bytes;

--- a/crates/interledger-store-redis/tests/settlement_test.rs
+++ b/crates/interledger-store-redis/tests/settlement_test.rs
@@ -1,12 +1,10 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod common;
 
 use bytes::Bytes;
 use common::*;
 use http::StatusCode;
 use interledger_settlement::SettlementStore;
+use lazy_static::lazy_static;
 use redis::{cmd, r#async::SharedConnection};
 
 lazy_static! {

--- a/crates/interledger-stream/src/client.rs
+++ b/crates/interledger-stream/src/client.rs
@@ -10,6 +10,7 @@ use interledger_packet::{
     PrepareBuilder, Reject,
 };
 use interledger_service::*;
+use log::{debug, error, warn};
 use std::{
     cell::Cell,
     cmp::min,

--- a/crates/interledger-stream/src/congestion.rs
+++ b/crates/interledger-stream/src/congestion.rs
@@ -3,6 +3,9 @@ use chrono::Utc;
 #[cfg(feature = "metrics_csv")]
 use csv;
 use interledger_packet::{ErrorCode, MaxPacketAmountDetails, Reject};
+#[cfg(test)]
+use lazy_static::lazy_static;
+use log::{debug, warn};
 use std::cmp::{max, min};
 #[cfg(feature = "metrics_csv")]
 use std::io;

--- a/crates/interledger-stream/src/crypto.rs
+++ b/crates/interledger-stream/src/crypto.rs
@@ -1,4 +1,7 @@
 use bytes::BytesMut;
+#[cfg(test)]
+use lazy_static::lazy_static;
+use log::error;
 use ring::rand::{SecureRandom, SystemRandom};
 use ring::{aead, digest, hmac};
 

--- a/crates/interledger-stream/src/error.rs
+++ b/crates/interledger-stream/src/error.rs
@@ -1,3 +1,5 @@
+use failure::Fail;
+
 #[derive(Fail, Debug)]
 pub enum Error {
     #[fail(display = "Error connecting: {}", _0)]

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -3,13 +3,6 @@
 //! Client and server implementations of the Interledger [STREAM](https://github.com/interledger/rfcs/blob/master/0029-stream/0029-stream.md) transport protocol.
 //!
 //! STREAM is responsible for splitting larger payments and messages into smaller chunks of money and data, and sending them over ILP.
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate failure;
 
 mod client;
 mod congestion;
@@ -31,6 +24,7 @@ pub mod test_helpers {
     use interledger_packet::Address;
     use interledger_router::RouterStore;
     use interledger_service::{Account, AccountStore};
+    use lazy_static::lazy_static;
     use std::iter::FromIterator;
     use std::str::FromStr;
 

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -5,6 +5,9 @@ use interledger_packet::{
     oer::{BufOerExt, MutBufOerExt},
     Address, PacketType as IlpPacketType, ParseError,
 };
+#[cfg(test)]
+use lazy_static::lazy_static;
+use log::warn;
 use std::{convert::TryFrom, fmt, str};
 
 const STREAM_VERSION: u8 = 1;

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -10,6 +10,7 @@ use interledger_packet::{
     RejectBuilder,
 };
 use interledger_service::{Account, BoxedIlpFuture, OutgoingRequest, OutgoingService};
+use log::{debug, warn};
 use std::convert::TryFrom;
 use std::marker::PhantomData;
 

--- a/crates/interledger/src/cli.rs
+++ b/crates/interledger/src/cli.rs
@@ -16,6 +16,8 @@ use interledger_service_util::ValidatorService;
 use interledger_spsp::{pay, SpspResponder};
 use interledger_store_memory::{Account, AccountBuilder, InMemoryStore};
 use interledger_stream::StreamReceiverService;
+use lazy_static::lazy_static;
+use log::debug;
 use parking_lot::RwLock;
 use ring::rand::{SecureRandom, SystemRandom};
 use std::str::FromStr;

--- a/crates/interledger/src/lib.rs
+++ b/crates/interledger/src/lib.rs
@@ -4,14 +4,6 @@
 #![recursion_limit = "128"]
 
 #[cfg(feature = "cli")]
-#[macro_use]
-extern crate log;
-
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(feature = "cli")]
-
 /// ILP Packet (De)Serialization
 pub mod packet {
     pub use interledger_packet::*;

--- a/crates/interledger/src/main.rs
+++ b/crates/interledger/src/main.rs
@@ -1,8 +1,5 @@
-extern crate interledger;
-#[macro_use]
-extern crate clap;
-
 use base64;
+use clap::value_t;
 use clap::{App, Arg, ArgGroup, SubCommand};
 use config;
 use hex;

--- a/crates/interledger/src/node.rs
+++ b/crates/interledger/src/node.rs
@@ -17,6 +17,7 @@ use interledger_service_util::{
 use interledger_settlement::{SettlementApi, SettlementMessageService};
 use interledger_store_redis::{Account, ConnectionInfo, IntoConnectionInfo, RedisStoreBuilder};
 use interledger_stream::StreamReceiverService;
+use log::{debug, error, info, trace};
 use ring::{digest, hmac};
 use serde::{de::Error as DeserializeError, Deserialize, Deserializer};
 use std::{net::SocketAddr, str};

--- a/crates/interledger/tests/btp_end_to_end.rs
+++ b/crates/interledger/tests/btp_end_to_end.rs
@@ -1,7 +1,3 @@
-extern crate interledger;
-#[macro_use]
-extern crate log;
-
 use env_logger;
 use futures::{
     future::{join_all, ok},
@@ -12,6 +8,7 @@ use interledger::{
     node::{AccountDetails, InterledgerNode},
 };
 use interledger_packet::Address;
+use log::debug;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
 

--- a/crates/interledger/tests/redis_helpers.rs
+++ b/crates/interledger/tests/redis_helpers.rs
@@ -1,10 +1,6 @@
 // Copied from https://github.com/mitsuhiko/redis-rs/blob/9a1777e8a90c82c315a481cdf66beb7d69e681a2/tests/support/mod.rs
 #![allow(dead_code)]
 
-extern crate futures;
-extern crate net2;
-extern crate rand;
-
 use redis;
 
 use std::env;
@@ -15,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use std::path::PathBuf;
 
-use self::futures::Future;
+use futures::Future;
 
 use redis::RedisError;
 

--- a/crates/interledger/tests/three_nodes.rs
+++ b/crates/interledger/tests/three_nodes.rs
@@ -1,10 +1,5 @@
 #![recursion_limit = "128"]
 
-extern crate interledger;
-extern crate reqwest;
-#[macro_use]
-extern crate serde_json;
-
 use env_logger;
 use futures::{future::join_all, Future, Stream};
 use interledger::{
@@ -12,6 +7,7 @@ use interledger::{
     node::{AccountDetails, InterledgerNode},
 };
 use interledger_packet::Address;
+use serde_json::json;
 use std::str;
 use std::str::FromStr;
 use tokio::runtime::Builder as RuntimeBuilder;


### PR DESCRIPTION
Progress towards #132. It turns out that tower-web is afflicted by a bug that makes it compatible only with the old-style `#[macro_use]` import, since that approach brought everything imaginable into the root scope and so it only happened to work by serendipity. The fix on their end would probably look something like https://github.com/graphql-rust/graphql-client/pull/180 (in general I think this is related to the note in the migration guide at https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#local-helper-macros ). I considered making a PR to tower-web but it has a few idling PRs and hasn't been updated in a few months, making me wonder whether we should look towards migrating to something else in the future (I'll file a separate issue for that). In any case, this style looks much more uniform, makes it easier to tell where identifiers are defined, and also makes it possible for the unused imports warning to work, which allowed me to outright eliminate some crates from some files.