### PR TITLE
Better error message when running tests without redis

### DIFF
--- a/crates/interledger/tests/redis_helpers.rs
+++ b/crates/interledger/tests/redis_helpers.rs
@@ -99,7 +99,10 @@ impl RedisServer {
             }
         };
 
-        let process = cmd.spawn().unwrap();
+        let process = cmd.spawn().expect(
+            "Could not spawn redis-server process, please ensure \
+             that all redis components are installed",
+        );
         RedisServer { process, addr }
     }
 


### PR DESCRIPTION
Fixes #143.

Secretly this PR is also intended to test whether or not CI is set up to look for new dependencies automatically, since a new patch version of crossbeam (which we transitively depend on) has been released to address an objection by cargo-audit, which we gate our CI on and which would previously cause PRs to be rejected spuriously. I assume this is the case, unless CI is trying to do some sneaky caching or something.