### PR TITLE
Remove dependence on hashbrown

### DIFF
--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -13,7 +13,6 @@ bytes = "0.4.12"
 byteorder = "1.3.1"
 chrono = "0.4.6"
 futures = "0.1.25"
-hashbrown = "0.1.8"
 interledger-ildcp = { path = "../interledger-ildcp", version = "0.2.1" }
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }
 interledger-service = { path = "../interledger-service", version = "0.2.1" }

--- a/crates/interledger-btp/src/service.rs
+++ b/crates/interledger-btp/src/service.rs
@@ -6,12 +6,12 @@ use futures::{
     sync::oneshot,
     Future, Sink, Stream,
 };
-use hashbrown::HashMap;
 use interledger_packet::{ErrorCode, Fulfill, Packet, Prepare, Reject, RejectBuilder};
 use interledger_service::*;
 use log::{debug, error, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use rand::random;
+use std::collections::HashMap;
 use std::{
     convert::TryFrom,
     io::{Error as IoError, ErrorKind},

--- a/crates/interledger-ccp/Cargo.toml
+++ b/crates/interledger-ccp/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/emschwartz/interledger-rs"
 bytes = "0.4.12"
 byteorder = "1.3.1"
 futures = "0.1.25"
-hashbrown = "0.1.8"
 hex = "0.3.2"
 interledger-ildcp = { path = "../interledger-ildcp", version = "0.2.1" }
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }

--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -11,9 +11,9 @@
 
 use bytes::Bytes;
 use futures::Future;
-use hashbrown::HashMap;
 use interledger_ildcp::IldcpAccount;
 use interledger_service::Account;
+use std::collections::HashMap;
 use std::{str::FromStr, string::ToString};
 
 #[cfg(test)]

--- a/crates/interledger-ccp/src/routing_table.rs
+++ b/crates/interledger-ccp/src/routing_table.rs
@@ -1,10 +1,10 @@
 use crate::packet::{Route, RouteUpdateRequest};
 use bytes::Bytes;
-use hashbrown::HashMap;
 use hex;
 use lazy_static::lazy_static;
 use log::{debug, trace};
 use ring::rand::{SecureRandom, SystemRandom};
+use std::collections::HashMap;
 use std::iter::FromIterator;
 
 lazy_static! {

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -6,7 +6,6 @@ use futures::{
     future::{err, ok},
     Future,
 };
-use hashbrown::HashMap;
 use interledger_packet::{Address, ErrorCode, RejectBuilder};
 use interledger_service::{
     incoming_service_fn, outgoing_service_fn, BoxedIlpFuture, IncomingService, OutgoingRequest,
@@ -15,6 +14,7 @@ use interledger_service::{
 #[cfg(test)]
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::{iter::FromIterator, sync::Arc};
 

--- a/crates/interledger-router/Cargo.toml
+++ b/crates/interledger-router/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/emschwartz/interledger-rs"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.25"
-hashbrown = "0.1.8"
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }
 interledger-service = { path = "../interledger-service", version = "0.2.1" }
 log = "0.4.6"

--- a/crates/interledger-router/src/lib.rs
+++ b/crates/interledger-router/src/lib.rs
@@ -13,8 +13,8 @@
 //! (see the `interledger-ccp` crate for more details).
 
 use bytes::Bytes;
-use hashbrown::HashMap;
 use interledger_service::{Account, AccountStore};
+use std::collections::HashMap;
 
 mod router;
 

--- a/crates/interledger-router/src/router.rs
+++ b/crates/interledger-router/src/router.rs
@@ -131,10 +131,10 @@ where
 mod tests {
     use super::*;
     use futures::future::ok;
-    use hashbrown::HashMap;
     use interledger_packet::{Address, FulfillBuilder, PrepareBuilder};
     use interledger_service::outgoing_service_fn;
     use parking_lot::Mutex;
+    use std::collections::HashMap;
     use std::iter::FromIterator;
     use std::str::FromStr;
     use std::sync::Arc;

--- a/crates/interledger-store-memory/Cargo.toml
+++ b/crates/interledger-store-memory/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/emschwartz/interledger-rs"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.25"
-hashbrown = "0.1.8"
 interledger-btp = { path = "../interledger-btp", version = "0.2.1" }
 interledger-http = { path = "../interledger-http", version = "0.2.1" }
 interledger-ildcp = { path = "../interledger-ildcp", version = "0.2.1" }

--- a/crates/interledger-store-memory/src/store.rs
+++ b/crates/interledger-store-memory/src/store.rs
@@ -4,13 +4,13 @@ use futures::{
     future::{err, ok},
     Future,
 };
-use hashbrown::HashMap;
 use interledger_btp::{BtpOpenSignupAccount, BtpOpenSignupStore, BtpStore};
 use interledger_http::HttpStore;
 use interledger_ildcp::IldcpAccount;
 use interledger_router::RouterStore;
 use interledger_service::{Account as AccountTrait, AccountStore};
 use parking_lot::{Mutex, RwLock};
+use std::collections::HashMap;
 use std::{
     cmp::max,
     iter::{empty, once, FromIterator, IntoIterator},

--- a/crates/interledger-store-redis/Cargo.toml
+++ b/crates/interledger-store-redis/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 bytes = "0.4.12"
 clap = "2.32.0"
 futures = "0.1.25"
-hashbrown = "0.1.8"
 interledger-api = { path = "../interledger-api", version = "0.1.0" }
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }
 interledger-btp = { path = "../interledger-btp", version = "0.2.1" }

--- a/crates/interledger-store-redis/src/store.rs
+++ b/crates/interledger-store-redis/src/store.rs
@@ -5,8 +5,8 @@ use futures::{
     future::{err, ok, result, Either},
     Future, Stream,
 };
-use hashbrown::{HashMap, HashSet};
 use log::{debug, error, trace, warn};
+use std::collections::{HashMap, HashSet};
 
 use http::StatusCode;
 use interledger_api::{AccountDetails, NodeStore};

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -19,7 +19,6 @@ chrono = "0.4.6"
 csv = { version = "1.0.5", optional = true }
 failure = "0.1.5"
 futures = "0.1.25"
-hashbrown = "0.1.8"
 hex = "0.3.2"
 interledger-ildcp = { path = "../interledger-ildcp", version = "0.2.1" }
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -19,12 +19,12 @@ pub use server::{ConnectionGenerator, StreamReceiverService};
 pub mod test_helpers {
     use bytes::Bytes;
     use futures::{future::ok, Future};
-    use hashbrown::HashMap;
     use interledger_ildcp::IldcpAccount;
     use interledger_packet::Address;
     use interledger_router::RouterStore;
     use interledger_service::{Account, AccountStore};
     use lazy_static::lazy_static;
+    use std::collections::HashMap;
     use std::iter::FromIterator;
     use std::str::FromStr;
 


### PR DESCRIPTION
Note that this involves changing a HashMap to a Vec in interledger-ccp, because we were implicitly relying on things being iterated upon in insertion order which is not something that HashMaps usually guarantee, leading to flaky tests upon switching implementations.

I would like someone who is more well-versed in the interledger-ccp logic to take a look at the changes there, since the switch from HashMap to Vec seemed a bit *too* easy. My worry is that there might be some implicit invariants that I'm not entirely sure are still upheld (though if not then I do at least think that the prior implementation may not have been intentionally upholding them either, so it's probably no *more* incorrect than it used to be). See my PR-level comments below for particular cases.

Fixes #130