### PR TITLE
Use chrono for date parsing and comparisons in the validator

### DIFF
--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/emschwartz/interledger-rs"
 [dependencies]
 bytes = "0.4.12"
 byteorder = "1.3.1"
+chrono = "0.4.7"
 futures = "0.1.25"
 hex = "0.3.2"
 interledger-packet = { path = "../interledger-packet", version = "0.2.1" }


### PR DESCRIPTION
Related to https://github.com/emschwartz/interledger-rs/issues/109

I'm not sure whether switching to `chrono` will solve the problem, but a) it might and b) the logs will be a bit more readable if it does.

Unfortunately the issue identified in #109 is hard to reproduce and it's unclear why it happens so I can't think of a better fix for it now. Anyone else have other ideas? If not, we could merge this and wait to see if the problem still arises in future builds.