### PR TITLE
update dependencies to use upstream crates

### DIFF
--- a/crates/interledger-settlement-engines/Cargo.toml
+++ b/crates/interledger-settlement-engines/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tower-web = "0.3.7"
 hex = "0.3.2"
-ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign/", rev = "64c0a269a19ab1282f8ede766fcf2db411fbc7a9" }
+ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign/", branch = "update-deps" }
 web3 = "0.8.0"
 log = "0.4.6"
 tokio = "0.1.21"

--- a/crates/interledger-settlement-engines/Cargo.toml
+++ b/crates/interledger-settlement-engines/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tower-web = "0.3.7"
 hex = "0.3.2"
-ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign/", branch = "update-deps" }
+ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign", branch = "update-deps" }
 web3 = "0.8.0"
 log = "0.4.6"
 tokio = "0.1.21"

--- a/crates/interledger-settlement-engines/Cargo.toml
+++ b/crates/interledger-settlement-engines/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tower-web = "0.3.7"
 hex = "0.3.2"
-ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign/", rev = "074da3c7038f84debdb0004f2e8f1be2778af3de" }
+ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign/", rev = "64c0a269a19ab1282f8ede766fcf2db411fbc7a9" }
 web3 = "0.8.0"
 log = "0.4.6"
 tokio = "0.1.21"

--- a/crates/interledger-settlement-engines/Cargo.toml
+++ b/crates/interledger-settlement-engines/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 [dependencies]
 tower-web = "0.3.7"
 hex = "0.3.2"
-ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign", branch = "exported-web3" }
+ethereum-tx-sign = { git = "https://github.com/gakonst/ethereum-tx-sign/", rev = "074da3c7038f84debdb0004f2e8f1be2778af3de" }
+web3 = "0.8.0"
 log = "0.4.6"
 tokio = "0.1.21"
 hyper = "0.12.31"
@@ -17,7 +18,7 @@ interledger-settlement = { path = "../interledger-settlement", version = "0.1.0"
 interledger-service-util = { path = "../interledger-service-util", version = "0.2.1" }
 interledger-store-redis = { path = "../interledger-store-redis", version = "0.2.1" }
 interledger-ildcp = { path = "../interledger-ildcp", version = "0.2.1" }
-ethabi = "6.1.0"
+ethabi = "8.0.1"
 serde = "1.0.91"
 serde_json = "1.0.40"
 json = "0.11.14"
@@ -32,10 +33,11 @@ tokio-retry = "0.2.0"
 redis = { version = "0.10.0", features = [ "with-unix-sockets" ] }
 http = "0.1.17"
 clap = "2.32.0"
-clarity = { git =  "https://github.com/gakonst/clarity" }
+clarity = "0.1.22"
 sha3 = "0.8.2"
 num-bigint = "0.2.2"
 num-traits = "0.2.8"
+lazy_static = "1.3.0"
 
 [dev-dependencies]
 lazy_static = "1.3"

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
@@ -6,13 +6,6 @@ use sha3::{Digest, Keccak256 as Sha3};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
-use web3::{
-    api::Web3,
-    futures::future::{err, join_all, ok, result, Either, Future},
-    futures::stream::Stream,
-    transports::Http,
-    types::{Address, BlockNumber, CallRequest, TransactionId, H256, U256},
-};
 use hyper::StatusCode;
 use interledger_store_redis::RedisStoreBuilder;
 use log::info;
@@ -33,6 +26,13 @@ use tokio::timer::Interval;
 use tokio_retry::{strategy::ExponentialBackoff, Retry};
 use url::Url;
 use uuid::Uuid;
+use web3::{
+    api::Web3,
+    futures::future::{err, join_all, ok, result, Either, Future},
+    futures::stream::Stream,
+    transports::Http,
+    types::{Address, BlockNumber, CallRequest, TransactionId, H256, U256},
+};
 
 use crate::stores::{redis_ethereum_ledger::*, LeftoversStore};
 use crate::{ApiResponse, CreateAccount, SettlementEngine, SettlementEngineApi};

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
@@ -6,7 +6,7 @@ use sha3::{Digest, Keccak256 as Sha3};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
-use ethereum_tx_sign::web3::{
+use web3::{
     api::Web3,
     futures::future::{err, join_all, ok, result, Either, Future},
     futures::stream::Stream,
@@ -659,13 +659,14 @@ where
         let signer = self.signer.clone();
 
         let mut tx = make_tx(to, amount, token_address);
+        let value = U256::from_str(&tx.value.to_string()).unwrap();
         let gas_amount_fut = web3.eth().estimate_gas(
             CallRequest {
                 to,
                 from: None,
                 gas: None,
                 gas_price: None,
-                value: Some(tx.value),
+                value: Some(value),
                 data: Some(tx.data.clone().into()),
             },
             None,
@@ -829,7 +830,7 @@ where
                                 let payment_details = payment_details.clone();
                                 move |recovered_address| {
                                     if recovered_address.as_bytes()
-                                        == &payment_details.to.own_address.to_vec()[..]
+                                        == &payment_details.to.own_address.as_bytes()[..]
                                     {
                                         ok(())
                                     } else {

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/mod.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/mod.rs
@@ -11,7 +11,7 @@ pub mod test_helpers;
 pub use eth_engine::{
     run_ethereum_engine, EthereumLedgerSettlementEngine, EthereumLedgerSettlementEngineBuilder,
 };
-pub use web3::types::Address as EthAddress;
 pub use types::{
     Addresses as EthereumAddresses, EthereumAccount, EthereumLedgerTxSigner, EthereumStore,
 };
+pub use web3::types::Address as EthAddress;

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/mod.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/mod.rs
@@ -11,7 +11,7 @@ pub mod test_helpers;
 pub use eth_engine::{
     run_ethereum_engine, EthereumLedgerSettlementEngine, EthereumLedgerSettlementEngineBuilder,
 };
-pub use ethereum_tx_sign::web3::types::Address as EthAddress;
+pub use web3::types::Address as EthAddress;
 pub use types::{
     Addresses as EthereumAddresses, EthereumAccount, EthereumLedgerTxSigner, EthereumStore,
 };

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/test_helpers.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/test_helpers.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
-use ethereum_tx_sign::web3::{
+use web3::{
     futures::future::{err, ok, Future},
     types::{Address, H256, U256},
 };

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/types.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/types.rs
@@ -1,11 +1,11 @@
 use clarity::{PrivateKey, Signature};
-use web3::types::{Address, H256, U256};
 use ethereum_tx_sign::RawTransaction;
 use futures::Future;
 use interledger_service::Account;
 use sha3::{Digest, Keccak256 as Sha3};
 use std::collections::HashMap;
 use std::str::FromStr;
+use web3::types::{Address, H256, U256};
 
 /// An Ethereum account is associated with an address. We additionally require
 /// that an optional `token_address` is implemented. If the `token_address` of an

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/types.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/types.rs
@@ -1,8 +1,6 @@
 use clarity::{PrivateKey, Signature};
-use ethereum_tx_sign::{
-    web3::types::{Address, H256, U256},
-    RawTransaction,
-};
+use web3::types::{Address, H256, U256};
+use ethereum_tx_sign::RawTransaction;
 use futures::Future;
 use interledger_service::Account;
 use sha3::{Digest, Keccak256 as Sha3};
@@ -108,8 +106,10 @@ impl EthereumLedgerTxSigner for String {
     fn address(&self) -> Address {
         let private_key: PrivateKey = self.parse().unwrap();
         let address = private_key.to_public_key().unwrap();
+        let mut out = [0; 20];
+        out.copy_from_slice(address.as_bytes());
         // Address type from clarity library must convert to web3 Address
-        Address::from(address.as_bytes())
+        Address::from(out)
     }
 }
 
@@ -124,7 +124,7 @@ mod tests {
         let addr = privkey.address();
         assert_eq!(
             addr,
-            Address::from("4070abbd2e38a8d27cd5a495f482c13f049f8310")
+            Address::from_str("4070abbd2e38a8d27cd5a495f482c13f049f8310").unwrap()
         );
     }
 
@@ -135,7 +135,7 @@ mod tests {
         let addr = privkey.address();
         assert_eq!(
             addr,
-            Address::from("e78cf81c309f27d5c509114471dcd7c0f9de05fa")
+            Address::from_str("e78cf81c309f27d5c509114471dcd7c0f9de05fa").unwrap()
         );
     }
 }

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/utils.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/utils.rs
@@ -1,14 +1,14 @@
 use ethabi::Token;
-use web3::{
-        api::Web3,
-        futures::future::Future,
-        transports::Http,
-        types::{Address, BlockNumber, FilterBuilder, Transaction, H160, H256, U256},
-};
 use ethereum_tx_sign::RawTransaction;
+use lazy_static::lazy_static;
 use log::error;
 use std::str::FromStr;
-use lazy_static::lazy_static;
+use web3::{
+    api::Web3,
+    futures::future::Future,
+    transports::Http,
+    types::{Address, BlockNumber, FilterBuilder, Transaction, H160, H256, U256},
+};
 
 lazy_static! {
     /// This is the result of keccak256("Transfer(address,address,to)"), which is
@@ -94,7 +94,7 @@ pub fn filter_transfer_logs(
         .topics(
             Some(vec![
                 // keccak256("transfer(address,address,to)")
-                TRANSFER_EVENT_FILTER.clone(),
+                *TRANSFER_EVENT_FILTER,
             ]),
             from,
             to,
@@ -157,7 +157,8 @@ mod tests {
         // https://etherscan.io/tx/0x6fd1b68f02f4201a38662647b7f09170b159faec6af4825ae509beefeb8e8130
         let to = "c92be489639a9c61f517bd3b955840fa19bc9b7c".parse().unwrap();
         let value = "16345785d8a0000".into();
-        let token_address = Some(H160::from_str("B8c77482e45F1F44dE1745F52C74426C631bDD52").unwrap());
+        let token_address =
+            Some(H160::from_str("B8c77482e45F1F44dE1745F52C74426C631bDD52").unwrap());
         let tx = make_tx(to, value, token_address);
         assert_eq!(tx.to, token_address);
         assert_eq!(tx.value, U256::from(0));

--- a/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/store.rs
+++ b/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/store.rs
@@ -3,10 +3,10 @@ use futures::{
     Future,
 };
 
-use web3::types::{Address as EthAddress, H256, U256};
 use interledger_service::Account as AccountTrait;
 use std::collections::HashMap;
 use std::str::FromStr;
+use web3::types::{Address as EthAddress, H256, U256};
 
 use crate::engines::ethereum_ledger::{EthereumAccount, EthereumAddresses, EthereumStore};
 use num_traits::Zero;
@@ -486,7 +486,8 @@ mod tests {
     fn saves_tx_hashes_properly() {
         block_on(test_store().and_then(|(store, context)| {
             let tx_hash =
-                H256::from_str("b28675771f555adf614f1401838b9fffb43bc285387679bcbd313a8dc5bdc00e").unwrap();
+                H256::from_str("b28675771f555adf614f1401838b9fffb43bc285387679bcbd313a8dc5bdc00e")
+                    .unwrap();
             store
                 .mark_tx_processed(tx_hash)
                 .map_err(|err| eprintln!("Redis error: {:?}", err))

--- a/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/store.rs
+++ b/crates/interledger-settlement-engines/src/stores/redis_ethereum_ledger/store.rs
@@ -3,7 +3,7 @@ use futures::{
     Future,
 };
 
-use ethereum_tx_sign::web3::types::{Address as EthAddress, H256, U256};
+use web3::types::{Address as EthAddress, H256, U256};
 use interledger_service::Account as AccountTrait;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -223,7 +223,9 @@ impl EthereumStore for EthereumLedgerRedisStore {
                             } else {
                                 return err(());
                             };
-                            let own_address = EthAddress::from(&own_address[..]);
+                            let mut out = [0; 20];
+                            out.copy_from_slice(own_address);
+                            let own_address = EthAddress::from(out);
 
                             let token_address =
                                 if let Some(token_address) = addr.get("token_address") {
@@ -232,7 +234,9 @@ impl EthereumStore for EthereumLedgerRedisStore {
                                     return err(());
                                 };
                             let token_address = if token_address.len() == 20 {
-                                Some(EthAddress::from(&token_address[..]))
+                                let mut out = [0; 20];
+                                out.copy_from_slice(token_address);
+                                Some(EthAddress::from(out))
                             } else {
                                 None
                             };
@@ -254,14 +258,14 @@ impl EthereumStore for EthereumLedgerRedisStore {
         let mut pipe = redis::pipe();
         for (account_id, d) in data {
             let token_address = if let Some(token_address) = d.token_address {
-                token_address.to_vec()
+                token_address.as_bytes().to_owned()
             } else {
                 vec![]
             };
             let acc_id = ethereum_ledger_key(account_id);
             let addrs = &[
-                ("own_address", d.own_address.to_vec()),
-                ("token_address", token_address),
+                ("own_address", d.own_address.as_bytes()),
+                ("token_address", &token_address),
             ];
             pipe.hset_multiple(acc_id, addrs).ignore();
             pipe.set(addrs_to_key(d), account_id).ignore();
@@ -482,7 +486,7 @@ mod tests {
     fn saves_tx_hashes_properly() {
         block_on(test_store().and_then(|(store, context)| {
             let tx_hash =
-                H256::from("0xb28675771f555adf614f1401838b9fffb43bc285387679bcbd313a8dc5bdc00e");
+                H256::from_str("b28675771f555adf614f1401838b9fffb43bc285387679bcbd313a8dc5bdc00e").unwrap();
             store
                 .mark_tx_processed(tx_hash)
                 .map_err(|err| eprintln!("Redis error: {:?}", err))


### PR DESCRIPTION
https://github.com/gakonst/ethereum-tx-sign is still being used until the maintainer merges https://github.com/synlestidae/ethereum-tx-sign/pull/10